### PR TITLE
Port 3cdd5441. Add max-11610 thermistors. Get Austin setup.

### DIFF
--- a/synse/devicebus/devices/i2c/max116xx_adc_thermistor.py
+++ b/synse/devicebus/devices/i2c/max116xx_adc_thermistor.py
@@ -53,6 +53,8 @@ class Max116xxThermistor(I2CDevice):
         super(Max116xxThermistor, self).__init__(**kwargs)
         logger.debug('Max116xxThermistor kwargs: {}'.format(kwargs))
 
+        _instance_name = None  # Must be overridden in a subclass.
+
         # Sensor specific commands.
         self._command_map[cid.READ] = self._read
 
@@ -132,7 +134,7 @@ class Max116xxThermistor(I2CDevice):
             dict: the thermistor reading value.
         """
         logger.debug('indirect_sensor_read')
-        data_file = self._get_bg_read_file('{0:04d}'.format(self.channel))
+        data_file = self._get_bg_read_file('{0:04x}'.format(self.channel))
         data = Max11608Thermistor.read_sensor_data_file(data_file)
         return {const.UOM_TEMPERATURE: data[0]}
 
@@ -155,7 +157,8 @@ class Max116xxThermistor(I2CDevice):
             elif self.hardware_type == 'production':
                 # Channel is zero based in the synse config.
                 # Read channel + 1 thermistors and return the last one read in the reading.
-                readings = i2c_common.read_thermistors(self.channel + 1, self.__class__._instance_name)
+                readings = i2c_common.read_thermistors(
+                    self.channel + 1, type(self)._instance_name)
                 return {const.UOM_TEMPERATURE: readings[self.channel]}
 
             else:

--- a/synse/devicebus/devices/i2c/sdp610_pressure.py
+++ b/synse/devicebus/devices/i2c/sdp610_pressure.py
@@ -147,7 +147,7 @@ class SDP610Pressure(I2CDevice):
             dict: the thermistor reading value.
         """
         logger.debug('indirect_sensor_read')
-        data_file = self._get_bg_read_file('{0:04d}'.format(self.channel))
+        data_file = self._get_bg_read_file('{0:04x}'.format(self.channel))
         data = SDP610Pressure.read_sensor_data_file(data_file)
         return {const.UOM_PRESSURE: data[0]}
 

--- a/synse/devicebus/devices/rs485/f660_airflow.py
+++ b/synse/devicebus/devices/rs485/f660_airflow.py
@@ -154,7 +154,7 @@ class F660Airflow(RS485Device):
             response = RS485Device.redirect_call_to_vec_leader(request.url)
             return {const.UOM_AIRFLOW: response[const.UOM_AIRFLOW]}
 
-        data_file = self._get_bg_read_file(str(self.unit), '{0:04d}'.format(self.register_base))
+        data_file = self._get_bg_read_file(str(self.unit), '{0:04x}'.format(self.register_base))
         data = F660Airflow.read_sensor_data_file(data_file)
         return {const.UOM_AIRFLOW: data[0]}
 

--- a/synse/devicebus/devices/rs485/gs3_2010_fan_controller.py
+++ b/synse/devicebus/devices/rs485/gs3_2010_fan_controller.py
@@ -283,7 +283,7 @@ class GS32010Fan(RS485Device):
             RS485Device.redirect_call_to_vec_leader(request.url)
             return
 
-        data_file = self._get_bg_write_file(str(self.unit), '{0:04d}'.format(self.register_base))
+        data_file = self._get_bg_write_file(str(self.unit), '{0:04x}'.format(self.register_base))
         logger.debug('data_file: {}, speed_rpm: {}'.format(data_file, speed_rpm))
 
         with open(data_file, 'w') as f:
@@ -303,7 +303,7 @@ class GS32010Fan(RS485Device):
             response = RS485Device.redirect_call_to_vec_leader(request.url)
             return response[const.UOM_VAPOR_FAN], response[const.UOM_DIRECTION]
 
-        data_file = self._get_bg_read_file(str(self.unit), '{0:04d}'.format(self.register_base))
+        data_file = self._get_bg_read_file(str(self.unit), '{0:04x}'.format(self.register_base))
         data = GS32010Fan.read_sensor_data_file(data_file)
         return (
             int(data[0]),  # rpm

--- a/synse/devicebus/devices/rs485/sht31_humidity.py
+++ b/synse/devicebus/devices/rs485/sht31_humidity.py
@@ -157,7 +157,7 @@ class SHT31Humidity(RS485Device):
             }
 
         data_file = self._get_bg_read_file(
-            str(self.unit), '{0:04d}'.format(self.register_base))
+            str(self.unit), '{0:04x}'.format(self.register_base))
         data = SHT31Humidity.read_sensor_data_file(data_file)
         return {
             const.UOM_TEMPERATURE: data[0],

--- a/synse/devicebus/fan_sensors.py
+++ b/synse/devicebus/fan_sensors.py
@@ -32,8 +32,9 @@ import json
 import logging
 
 from synse.devicebus.devices.i2c.max116xx_adc_thermistor import \
-    Max11608Thermistor
+    Max11608Thermistor, Max11610Thermistor
 from synse.devicebus.devices.i2c.sdp610_pressure import SDP610Pressure
+from synse.errors import SynseException
 from synse.protocols.i2c_common import i2c_common
 from synse.vapor_common.vapor_config import ConfigManager
 
@@ -41,8 +42,10 @@ logger = logging.getLogger(__name__)
 
 
 class FanSensor(object):
-    """ Simple data about a sensor. These sensors are all related to auto-fan
-    and may not be on the fan controller proper. (Most are not).
+    """Collection of all sensors on a single VEC read in parallel by auto-fan.
+    This represents a single read of all sensors except the ones on the the
+    shared bus. These are the thermistors and differential pressure
+    sensors.
     """
     def __init__(self, name, units, device):
         if name is None:
@@ -118,16 +121,24 @@ class FanSensors(object):
 
         # From i2c.
 
-        # FUTURE: We should probably do this the way the i2c daemon does it by reading
-        # the synse config.
+        # Supported thermistor types are Max11610Thermistor and Max11608Thermistor.
+        max_11610_thermistors = self._find_devices_by_instance_name(
+            Max11610Thermistor.get_instance_name())
 
-        # FUTURE: All thermistors need the same device_name to support bulk reads.
-        # It doesn't matter now since we're not even using device_name from the synse
-        # config for production i2c sensor reads. Also true for differential pressure
-        # (i2c as well).
-        self.thermistor_devices = self._find_devices_by_instance_name(
+        max_11608_thermistors = self._find_devices_by_instance_name(
             Max11608Thermistor.get_instance_name())
-        # List length FanSensors.SUPPORTED_THERMISTOR_COUNT, all entries are None.
+
+        # Thermistors must all be the same type for bulk reads.
+        if len(max_11610_thermistors) != 0 and len(max_11608_thermistors) != 0:
+            raise SynseException('Found multiple thermistor models which is not supported')
+
+        if len(max_11610_thermistors) != 0:
+            self.thermistor_devices = self._find_devices_by_instance_name(
+                Max11610Thermistor.get_instance_name())
+        else:
+            self.thermistor_devices = self._find_devices_by_instance_name(
+                Max11608Thermistor.get_instance_name())
+
         self.thermistors = [None] * FanSensors.SUPPORTED_THERMISTOR_COUNT
         for d in self.thermistor_devices:
             channel = d.channel
@@ -279,9 +290,11 @@ class FanSensors(object):
 
     def _read_thermistors_direct(self):
         """Read the configured thermistors by hitting the bus."""
-        readings = i2c_common.read_thermistors(self.thermistor_read_count)
-        for i, reading in enumerate(readings):
-            self.thermistors[i].reading = reading
+        if self.thermistor_read_count < 0:
+            thermistor_model = type(self.thermistors)._instance_name
+            readings = i2c_common.read_thermistors(self.thermistor_read_count, thermistor_model)
+            for i, reading in enumerate(readings):
+                self.thermistors[i].reading = reading
 
     def _read_thermistors_indirect(self):
         """Read the configured thermistors without hitting the bus."""

--- a/synse/protocols/conversions/conversions.py
+++ b/synse/protocols/conversions/conversions.py
@@ -55,13 +55,13 @@ def convert_thermistor_reading(ad_reading, index, device_name):
     :param index: The index into the raw reading to convert. This is underneath
     a bulk read. Two bytes per individual thermistor reading in ad_reading.
     :param device_name: The type of A/D converter that the thermistor is
-    plugged in to. max_11610 and max_1108 are supported.
+    plugged in to. max-11610 and max-1108 are supported.
     :returns: The temperature in degrees C, or None if no thermistor attached.
     :raises: ValueError on unsupported device_name."""
-    if device_name == 'max_11610':
+    if device_name == 'max-11610':
         temperature = thermistor_max11610_adc(
             ad_reading[index:index + 2])
-    elif device_name == 'max_11608':
+    elif device_name == 'max-11608':
         temperature = thermistor_max11608_adc(
             ad_reading[index:index + 2])
     else:

--- a/synse/protocols/i2c_common/i2c_common.py
+++ b/synse/protocols/i2c_common/i2c_common.py
@@ -598,13 +598,13 @@ def write_led(state, color=None, blink_state=None):
 def _get_thermistor_registers(device_name):
     """Get the read and write registers for the max116xx A/D converter attached
     to a thermistor.
-    :param device_name: max_11608 and max_11610 are supported.
+    :param device_name: max-11608 and max-11610 are supported.
     :returns: read_register, write_register.
     :raises ValueError if device_name is not supported"""
-    if device_name == 'max_11610':
+    if device_name == 'max-11610':
         read_register = '\x6B'
         write_register = '\x6A'
-    elif device_name == 'max_11608':
+    elif device_name == 'max-11608':
         read_register = '\x67'
         write_register = '\x66'
     else:
@@ -616,7 +616,7 @@ def _get_thermistor_registers(device_name):
 def read_thermistors(count, device_name):
     """This will read count number of thermistors from the CEC board.
     :param count: The number of thermistors to read.
-    :param: device_name max_11608 and max_11610 are supported.
+    :param device_name: max-11608 and max-11610 are supported.
     :returns: An array of thermistor readings in degrees Celsius. The array
     index will be the same as the channel in the synse i2c max-11608 thermistor
     configuration."""

--- a/synse/utils.py
+++ b/synse/utils.py
@@ -436,10 +436,15 @@ def get_device_instance(board_id):
     if device is not None:
         return device
 
-    raise SynseException(
-        'Board ID ({}) not associated with any registered devicebus handler.'.format(board_id)
-    )
-
+    # If board_id is a string it should be hex. If board_id is an int, format as hex.
+    if isinstance(board_id, basestring):
+        raise SynseException(
+            'Board ID ({}) not associated with any registered devicebus handler.'.format(board_id)
+        )
+    else:
+        raise SynseException(
+            'Board ID ({:08x}) not associated with any registered devicebus handler.'.format(board_id)
+        )
 
 # -------------------------------------
 # Threaded Registration Utilities

--- a/synse/vapor_common/tests/utils/strings.py
+++ b/synse/vapor_common/tests/utils/strings.py
@@ -73,7 +73,7 @@ class _S(object):
     # TODO: Ticket. Should probably read device type rather than sensor type. (553)
     ERROR_WRONG_DEVICE_TYPE = 'Wrong sensor type. ' \
                               'Request to read {}, but this sensor reads {}.'
-    ERROR_NO_REGISTERED_DEVICE_FOR_BOARD = 'Board ID ({}) not associated with any registered devicebus handler.'
+    ERROR_NO_REGISTERED_DEVICE_FOR_BOARD = 'Board ID ({:08x}) not associated with any registered devicebus handler.'
 
     LED_COLOR = 'led_color'
     LED_STATE = 'led_state'


### PR DESCRIPTION
**Review Deadline**: 

## Summary
Ports MAX11610 Thermistor to synse-server.
The last two files are changes for formatting board_id in hex.
The indirect reads do not belong here, but that is a separate issue.
## Related Issues
- 

## Checklist
- [ ] tests passing
- [ ] code linted/formatted (if applicable)

## Notes
