### PR TITLE
Bump up PLC timeouts. Add sleeps to allow emulators to configure. Log…

### DIFF
--- a/bin/synse.sh
+++ b/bin/synse.sh
@@ -145,6 +145,10 @@ function start-plc-emulator {
     socat PTY,link=/dev/ttyVapor001,mode=666 PTY,link=/dev/ttyVapor002,mode=666 &
     python -u /synse/synse/emulator/plc/devicebus_emulator.py $1 &
 
+    # Sleep for a short bit - this is to give the emulator enough time to start
+    # up and configure before synse starts hitting it with requests.
+    sleep 0.25
+
 }; function emulate-plc-with-cfg {
     cp /synse/configs/synse/plc/synse_config.json /synse/override/config.json
 
@@ -170,6 +174,10 @@ function start-i2c-emulator {
     socat PTY,link=/dev/ttyVapor005,mode=666 PTY,link=/dev/ttyVapor006,mode=666 &
     python -u /synse/synse/emulator/i2c/i2c_emulator.py $1 &
 
+    # Sleep for a short bit - this is to give the emulator enough time to start
+    # up and configure before synse starts hitting it with requests.
+    sleep 0.25
+
 }; function emulate-i2c-with-cfg {
     cp /synse/configs/synse/i2c/synse_config.json /synse/override/config.json
 
@@ -194,6 +202,10 @@ function start-rs485-emulator {
 
     socat PTY,link=/dev/ttyVapor003,mode=666 PTY,link=/dev/ttyVapor004,mode=666 &
     python -u /synse/synse/emulator/rs485/rs485_emulator.py $1 &
+
+    # Sleep for a short bit - this is to give the emulator enough time to start
+    # up and configure before synse starts hitting it with requests.
+    sleep 0.25
 
 }; function emulate-rs485-with-cfg {
     cp /synse/configs/synse/rs485/synse_config.json /synse/override/config.json

--- a/sample/config_plc.json
+++ b/sample/config_plc.json
@@ -15,7 +15,7 @@
               {
                 "device_name": "/dev/ttyVapor002",
                 "retry_limit": 3,
-                "timeout": 0.25,
+                "timeout": 0.50,
                 "time_slice": 75,
                 "bps": 115200
               }

--- a/synse/devicebus/devices/plc/plc_bus.py
+++ b/synse/devicebus/devices/plc/plc_bus.py
@@ -259,12 +259,14 @@ class DeviceBusPacket(object):
                 # them as-is, instead of collecting them under a general failure
                 logger.debug('<<Invalid_data ({}): {}'.format(e.message, str([hex(x) for x in serialbytes])))
                 raise e
-            except Exception:
+            except Exception as e:
                 # a catchall exception used to indicate that something bad has
                 # happened - this could be related to errors reading off the bus
                 # or reading nothing at all. in either case, we are unable to
                 # recover, so BusTimeoutException is passed up the chain for
                 # appropriate handling.
+                logger.error('Failed to communicate on PLC bus.')
+                logger.exception(e)
                 raise BusTimeoutException('No response from bus.')
 
         elif data_bytes is not None:

--- a/synse/devicebus/devices/plc/plc_device.py
+++ b/synse/devicebus/devices/plc/plc_device.py
@@ -89,7 +89,7 @@ class PLCDevice(SerialDevice):
 
         # these are optional values, so they may not exist in the config.
         # if they do not exist, they will hold a default value
-        self.bus_timeout = kwargs.get('timeout', 0.25)
+        self.bus_timeout = kwargs.get('timeout', 0.50)
         self.bus_baud = kwargs.get('bps', 115200)
         self.retry_limit = kwargs.get('retry_limit', 3)
         self.time_slice = kwargs.get('time_slice', 75)
@@ -202,7 +202,7 @@ class PLCDevice(SerialDevice):
                 rack_lockfile = rack['lockfile']
                 rack_id = rack['rack_id']  # pylint: disable=unused-variable
                 hardware_type = rack['hardware_type']
-                rack_timeout = rack.get('timeout', 0.25)  # pylint: disable=unused-variable
+                rack_timeout = rack.get('timeout', 0.50)  # pylint: disable=unused-variable
                 counter = app_config['COUNTER']
 
                 for plc_config in rack['devices']:


### PR DESCRIPTION
…ging.

**Review Deadline**: 

## Summary

I got a 90% pass rate by CircleCI with this over 10 runs. Yesterday I have about 5 runs fail in a row with PLC failures. Details below:

```
------------------------
Score:
------------------------
mhink-plc-hates-me (Matt's fix): Pass 10 Fail 5 Rate 67%
mhink-plc-hates-me-merged (Matt and Erick's fix): Pass 9 Fail 1 Rate 90%

------------------------
Passing CircleCI builds:
------------------------

https://circleci.com/gh/vapor-ware/synse-server/38 (Matt's fix)
https://circleci.com/gh/vapor-ware/synse-server/40 (Matt's fix)
https://circleci.com/gh/vapor-ware/synse-server/42 (Matt's fix)
https://circleci.com/gh/vapor-ware/synse-server/44 (Matt's fix)
https://circleci.com/gh/vapor-ware/synse-server/47 (Matt's fix)
https://circleci.com/gh/vapor-ware/synse-server/54 (Matt's fix)
https://circleci.com/gh/vapor-ware/synse-server/56 (Matt's fix)
https://circleci.com/gh/vapor-ware/synse-server/58 (Matt's fix)
https://circleci.com/gh/vapor-ware/synse-server/62 (Matt's fix)
https://circleci.com/gh/vapor-ware/synse-server/66 (Matt's fix)

https://circleci.com/gh/vapor-ware/synse-server/48 (Merge of Matt's and Erick's fixes)
https://circleci.com/gh/vapor-ware/synse-server/50 (Merge of Matt's and Erick's fixes)
https://circleci.com/gh/vapor-ware/synse-server/52 (Merge of Matt's and Erick's fixes)
https://circleci.com/gh/vapor-ware/synse-server/55 (Merge of Matt's and Erick's fixes)
https://circleci.com/gh/vapor-ware/synse-server/57 (Merge of Matt's and Erick's fixes)
https://circleci.com/gh/vapor-ware/synse-server/59 (Merge of Matt's and Erick's fixes)
https://circleci.com/gh/vapor-ware/synse-server/61 (Merge of Matt's and Erick's fixes)
https://circleci.com/gh/vapor-ware/synse-server/64 (Merge of Matt's and Erick's fixes)
https://circleci.com/gh/vapor-ware/synse-server/67 (Merge of Matt's and Erick's fixes)


------------------------
Failing CircleCI builds:
------------------------
https://circleci.com/gh/vapor-ware/synse-server/49 (Matt's fix)
- Looks like a similar failure in plc endurance

https://circleci.com/gh/vapor-ware/synse-server/51 (Matt's fix)
- Looks like a similar failure in plc endurance

https://circleci.com/gh/vapor-ware/synse-server/53 (Matt's fix)
- Looks like a similar failure in plc endurance

https://circleci.com/gh/vapor-ware/synse-server/60 (Matt's fix)
- scan bus timeout in test-plc-emulator

https://circleci.com/gh/vapor-ware/synse-server/65 (Matt's fix)
- Looks like a similar failure in plc endurance

https://circleci.com/gh/vapor-ware/synse-server/46 (Merge of Matt's and Erick's fixes)
- scan bus timeout in test-endpoint-utils

------------------------
Running CircleCI builds:
------------------------
https://circleci.com/gh/vapor-ware/synse-server/67 (Merge of Matt's and Erick's fixes)
```

## Related Issues
- 

## Checklist
- [ ] tests passing
- [ ] code linted/formatted (if applicable)

## Notes
