### PR TITLE
Remove indirect reads from i2c devices.

### DIFF
--- a/synse/devicebus/devices/i2c/max116xx_adc_thermistor.py
+++ b/synse/devicebus/devices/i2c/max116xx_adc_thermistor.py
@@ -112,33 +112,6 @@ class Max116xxThermistor(I2CDevice):
                 device_id)), None, sys.exc_info()[2]
 
     def _read_sensor(self):
-        """ Convenience method to return the sensor reading.
-
-        If the sensor is configured to be read indirectly (e.g. from background)
-        it will do so -- otherwise, we perform a direct read.
-        """
-        logger.debug('self.from_background: {}'.format(self.from_background))
-        if self.from_background:
-            return self.indirect_sensor_read()
-        return self._direct_sensor_read()
-
-    def indirect_sensor_read(self):
-        """Read the sensor data from the intermediary data file.
-
-        FIXME - reading from file is only for the POC. once we can
-        confirm that this works and have it stable for the short-term, we
-        will need to move on to the longer-term plan of having this done
-        via socket.
-
-        Returns:
-            dict: the thermistor reading value.
-        """
-        logger.debug('indirect_sensor_read')
-        data_file = self._get_bg_read_file('{0:04x}'.format(self.channel))
-        data = Max11608Thermistor.read_sensor_data_file(data_file)
-        return {const.UOM_TEMPERATURE: data[0]}
-
-    def _direct_sensor_read(self):
         """ Internal method for reading data off of the device.
 
         Returns:

--- a/synse/devicebus/devices/i2c/sdp610_pressure.py
+++ b/synse/devicebus/devices/i2c/sdp610_pressure.py
@@ -126,34 +126,8 @@ class SDP610Pressure(I2CDevice):
                 device_id)), None, sys.exc_info()[2]
 
     def _read_sensor(self):
-        """ Convenience method to return the sensor reading.
-
-        If the sensor is configured to be read indirectly (e.g. from background)
-        it will do so -- otherwise, we perform a direct read.
-        """
-        if self.from_background:
-            return self.indirect_sensor_read()
-        return self._direct_sensor_read()
-
-    def indirect_sensor_read(self):
-        """Read the sensor data from the intermediary data file.
-
-        FIXME - reading from file is only for the POC. once we can
-        confirm that this works and have it stable for the short-term, we
-        will need to move on to the longer-term plan of having this done
-        via socket.
-
-        Returns:
-            dict: the thermistor reading value.
-        """
-        logger.debug('indirect_sensor_read')
-        data_file = self._get_bg_read_file('{0:04x}'.format(self.channel))
-        data = SDP610Pressure.read_sensor_data_file(data_file)
-        return {const.UOM_PRESSURE: data[0]}
-
-    def _direct_sensor_read(self):
-        """ Internal method for reading data off of the device.
-
+        """ Convenience method to return the sensor reading from the bus.
+        
         Returns:
             dict: the pressure reading value.
         """

--- a/synse/devicebus/fan_sensors.py
+++ b/synse/devicebus/fan_sensors.py
@@ -282,49 +282,19 @@ class FanSensors(object):
             return i2c_config
 
     def _read_thermistors(self):
-        """Read the configured thermistors."""
-        if self.from_background:
-            self._read_thermistors_indirect()
-        else:
-            self._read_thermistors_direct()
-
-    def _read_thermistors_direct(self):
         """Read the configured thermistors by hitting the bus."""
         if self.thermistor_read_count < 0:
-            thermistor_model = type(self.thermistors)._instance_name
+            thermistor_model = type(self.thermistors).get_instance_name()
             readings = i2c_common.read_thermistors(self.thermistor_read_count, thermistor_model)
             for i, reading in enumerate(readings):
                 self.thermistors[i].reading = reading
 
-    def _read_thermistors_indirect(self):
-        """Read the configured thermistors without hitting the bus."""
-        for t in self.thermistor_devices:
-            channel = t.channel
-            data = t.indirect_sensor_read()[const.UOM_TEMPERATURE]
-            self.thermistors[channel].reading = data
-        logger.debug('_read_thermistors_indirect: {}'.format(self.thermistors))
-
     def _read_differential_pressures(self):
-        """Read the configured differential pressure sensors."""
-        if self.from_background:
-            self._read_differential_pressures_indirect()
-        else:
-            self._read_differential_pressures_direct()
-
-    def _read_differential_pressures_direct(self):
         """Read the configured differential pressure sensors by hitting the bus."""
-        readings = i2c_common.read_differential_pressures(self.differential_pressure_read_count)
+        readings = i2c_common.read_differential_pressures(
+            self.differential_pressure_read_count)
         for i, reading in enumerate(readings):
             self.differential_pressures[i].reading = reading
-
-    def _read_differential_pressures_indirect(self):
-        """Read the configured differential pressure sensors without hitting the bus."""
-        for dp in self.differential_pressure_devices:
-            channel = dp.channel
-            ordinal = i2c_common.get_channel_ordinal(channel)
-            data = dp.indirect_sensor_read()[const.UOM_PRESSURE]
-            self.differential_pressures[ordinal].reading = data
-        logger.debug('_read_diff_pressures_indirect: {}'.format(self.differential_pressures))
 
     def _thermistor_read_count(self):
         """ Determine the number of thermistors to read on each


### PR DESCRIPTION
**Review Deadline**: 

## Summary
I2C side fix for https://github.com/vapor-ware/synse-server/issues/6
RS485 PR pending.
This diff looks a little funky. I just moved the direct sensor read/write code up into the read/write sensor function.
## Related Issues
- 

## Checklist
- [ ] tests passing
- [ ] code linted/formatted (if applicable)

## Notes
