### PR TITLE
set default gRPC timeout to 3s

### DIFF
--- a/synse/config.py
+++ b/synse/config.py
@@ -124,7 +124,7 @@ def load_default_configs():
             }
         },
         'grpc': {
-            'timeout': 20
+            'timeout': 3
         }
     }
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -70,7 +70,7 @@ def test_load_default_configs(clear_config):
             }
         },
         'grpc': {
-            'timeout': 20
+            'timeout': 3
         }
     }
 


### PR DESCRIPTION
**Review Deadline**: --

## Summary
Reduces the default gRPC request timeout from 20s to 3s

## Related Issues
- fixes #30
