### PR TITLE
test + fixture cleanup, some bug fixes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,4 +4,4 @@ universal = 1
 [isort]
 not_skip = __init__.py
 default_section = THIRDPARTY
-known_first_party = synse
+known_first_party = synse,tests

--- a/synse/commands/transaction.py
+++ b/synse/commands/transaction.py
@@ -19,6 +19,11 @@ async def check_transaction(transaction_id):
     """
 
     transaction = await cache.get_transaction(transaction_id)
+    if not transaction:
+        raise errors.TransactionNotFoundError(
+            gettext('Transaction with id "{}" not found').format(transaction_id)
+        )
+
     plugin_name = transaction.get('plugin')
     context = transaction.get('context')
 

--- a/synse/plugin.py
+++ b/synse/plugin.py
@@ -4,8 +4,7 @@
 import os
 import stat
 
-from synse import config, errors
-from synse.const import SOCKET_DIR
+from synse import config, const, errors
 from synse.i18n import gettext
 from synse.log import logger
 from synse.proto.client import register_client
@@ -212,7 +211,7 @@ def register_unix_plugins():
             # This will give us a 'name' here of 'plugin_name' and a 'path'
             # of None.
             if path is None:
-                path = SOCKET_DIR
+                path = const.SOCKET_DIR
 
             # Check for both 'plugin_name' and 'plugin_name.sock'
             sock_path = os.path.join(path, name, '.sock')
@@ -243,18 +242,18 @@ def register_unix_plugins():
 
     # Now go through the default socket directory to pick up any other sockets
     # that may be set for automatic registration.
-    if not os.path.exists(SOCKET_DIR):
+    if not os.path.exists(const.SOCKET_DIR):
         logger.debug(
             gettext('default socket path does not exist, no plugins registered from {}')
-            .format(SOCKET_DIR)
+            .format(const.SOCKET_DIR)
         )
 
     else:
         logger.debug(gettext('socket dir exists'))
 
-        for item in os.listdir(SOCKET_DIR):
+        for item in os.listdir(const.SOCKET_DIR):
             logger.debug('  {}'.format(item))
-            fqn = os.path.join(SOCKET_DIR, item)
+            fqn = os.path.join(const.SOCKET_DIR, item)
             name, _ = os.path.splitext(item)
 
             if stat.S_ISSOCK(os.stat(fqn).st_mode):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+"""Tests for Synse Server"""
+
+import os
+
+data_dir = os.path.expanduser('~/_tmp_test')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,33 +1,41 @@
-"""Test configuration for Synse Server.
+"""Test configuration for Synse Server for all tests.
 """
 
 import logging
-import os
-import shutil
 
 import pytest
 
-from synse import const
+from synse import config, factory
+
+_app = None
+
+
+@pytest.fixture(scope='session')
+def app():
+    """Fixture to get a Synse Server application instance."""
+    global _app
+    if _app is None:
+        _app = factory.make_app()
+    return _app
+
+
+@pytest.fixture(autouse=True)
+def disable_logging():
+    """The loggers. This makes test output much cleaner/easier to read."""
+    logging.getLogger('synse').disabled = True
+    logging.getLogger('root').disabled = True
+    logging.getLogger('sanic.access').disabled = True
+
+
+@pytest.fixture()
+def no_pretty_json():
+    """Fixture to ensure basic JSON responses."""
+    config.options['pretty_json'] = False
 
 
 @pytest.fixture(autouse=True)
 def i18n_passthrough():
-    """Sets i18n.trans_func, just like if i18n.init_gettext was called.
-        If you encounter the following error, you need to include this fixture.
-
-    ```
-def gettext(text):
-    if trans_func:
-        return trans_func(text)
-    else:
-        raise RuntimeError(
->               'i18n.gettext() not yet initialized, i18n.init_gettext() mus be called first.'
-                )
-E       RuntimeError: i18n.gettext() not yet initialized, i18n.init_gettext() mus be called first.
-
-synse/i18n.py:62: RuntimeError
-    ```
-    """
+    """Sets i18n.trans_func, just like if i18n.init_gettext was called."""
     from synse import i18n
     old_trans_func = i18n.trans_func
     i18n.old_trans_func = old_trans_func
@@ -37,28 +45,3 @@ synse/i18n.py:62: RuntimeError
     yield
 
     i18n.trans_func = old_trans_func
-
-
-@pytest.fixture()
-def plugin_dir():
-    """Fixture to setup and teardown the test context for creating plugins."""
-    # create paths that will be used by the plugins
-
-    if not os.path.isdir(const.SOCKET_DIR):
-        os.makedirs(const.SOCKET_DIR)
-
-    yield
-
-    # cleanup
-    if os.path.isdir(const.SOCKET_DIR):
-        shutil.rmtree(const.SOCKET_DIR)
-
-
-@pytest.fixture(autouse=True)
-def disable_synse_logging():
-    """Disable the synse logger. Negative tests cases will cause
-    warning and error level messages to be logged out which can
-    make the test output confusing.
-    """
-    l = logging.getLogger('synse')
-    l.disabled = True

--- a/tests/integration/routes/aliases/test_boot_target_route.py
+++ b/tests/integration/routes/aliases/test_boot_target_route.py
@@ -1,46 +1,17 @@
-"""Test the 'synse.routes.aliases' Synse Server module's boot target route."""
+"""Test the 'synse.routes.aliases' module's boot target route."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
-import ujson
-
-from synse import config, errors, factory
+from synse import errors
 from synse.version import __api_version__
+from tests import utils
 
 invalid_boot_target_route_url = '/synse/{}/boot_target/invalid-rack/invalid-board/invalid-device'.format(__api_version__)
 
 
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
-
-
 def test_boot_target_endpoint_invalid(app):
-    """Test getting a invalid boot target response.
-
-    Details:
-        In this case, rack, board, device are invalid.
-        However, the returned error should be DEVICE_NOT_FOUND
-        instead of RACK_NOT_FOUND, even though it is also true.
-
-        There is no need to check for a request with query paramter(s)
-        because the device is not found anyway.
-    """
+    """Get boot target info for a nonexistent device."""
     _, response = app.test_client.get(invalid_boot_target_route_url)
-
-    assert response.status == 500
-
-    data = ujson.loads(response.text)
-
-    assert 'http_code' in data
-    assert 'error_id' in data
-    assert 'description' in data
-    assert 'timestamp' in data
-    assert 'context' in data
-
-    assert data['http_code'] == 500
-    assert data['error_id'] == errors.DEVICE_NOT_FOUND
+    utils.test_error_json(response, errors.DEVICE_NOT_FOUND)
 
 
 def test_boot_target_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/aliases/test_fan_route.py
+++ b/tests/integration/routes/aliases/test_fan_route.py
@@ -1,46 +1,17 @@
-"""Test the 'synse.routes.aliases' Synse Server module's fan route."""
+"""Test the 'synse.routes.aliases' module's fan route."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
-import ujson
-
-from synse import config, errors, factory
+from synse import errors
 from synse.version import __api_version__
+from tests import utils
 
 invalid_fan_route_url = '/synse/{}/fan/invalid-rack/invalid-board/invalid-device'.format(__api_version__)
 
 
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
-
-
 def test_fan_endpoint_invalid(app):
-    """Test getting a invalid fan response.
-
-    Details:
-        In this case, rack, board, device are invalid.
-        However, the returned error should be DEVICE_NOT_FOUND,
-        instead of RACK_NOT_FOUND, even though it is also true.
-
-        There is no need to check for a request with query paramter(s)
-        because the device is not found anyway.
-    """
+    """Get fan info for a nonexistent device."""
     _, response = app.test_client.get(invalid_fan_route_url)
-
-    assert response.status == 500
-
-    data = ujson.loads(response.text)
-
-    assert 'http_code' in data
-    assert 'error_id' in data
-    assert 'description' in data
-    assert 'timestamp' in data
-    assert 'context' in data
-
-    assert data['http_code'] == 500
-    assert data['error_id'] == errors.DEVICE_NOT_FOUND
+    utils.test_error_json(response, errors.DEVICE_NOT_FOUND)
 
 
 def test_fan_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/aliases/test_led_route.py
+++ b/tests/integration/routes/aliases/test_led_route.py
@@ -1,46 +1,17 @@
-"""Test the 'synse.routes.aliases' Synse Server module's led route."""
+"""Test the 'synse.routes.aliases' module's led route."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
-import ujson
-
-from synse import config, errors, factory
+from synse import errors
 from synse.version import __api_version__
+from tests import utils
 
 invalid_led_route_url = '/synse/{}/led/invalid-rack/invalid-board/invalid-device'.format(__api_version__)
 
 
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
-
-
 def test_led_endpoint_invalid(app):
-    """Test getting a invalid led response.
-
-    Details:
-        In this case, rack, board, device are invalid.
-        However, the returned error should be DEVICE_NOT_FOUND,
-        instead of RACK_NOT_FOUND, even though it is also true.
-
-        There is no need to check for a request with query paramter(s)
-        because the device is not found anyway.
-    """
+    """Get LED info for a nonexistent device."""
     _, response = app.test_client.get(invalid_led_route_url)
-
-    assert response.status == 500
-
-    data = ujson.loads(response.text)
-
-    assert 'http_code' in data
-    assert 'error_id' in data
-    assert 'description' in data
-    assert 'timestamp' in data
-    assert 'context' in data
-
-    assert data['http_code'] == 500
-    assert data['error_id'] == errors.DEVICE_NOT_FOUND
+    utils.test_error_json(response, errors.DEVICE_NOT_FOUND)
 
 
 def test_led_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/aliases/test_power_route.py
+++ b/tests/integration/routes/aliases/test_power_route.py
@@ -1,46 +1,17 @@
-"""Test the 'synse.routes.aliases' Synse Server module's power route."""
+"""Test the 'synse.routes.aliases' module's power route."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
-import ujson
-
-from synse import config, errors, factory
+from synse import errors
 from synse.version import __api_version__
+from tests import utils
 
 invalid_power_route_url = '/synse/{}/power/invalid-rack/invalid-board/invalid-device'.format(__api_version__)
 
 
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
-
-
 def test_power_endpoint_invalid(app):
-    """Test getting a invalid power response.
-
-    Details:
-        In this case, rack, board, device are invalid.
-        However, the returned error should be DEVICE_NOT_FOUND,
-        instead of RACK_NOT_FOUND, even though it is also true.
-
-        There is no need to check for a request with query paramter(s)
-        because the device is not found anyway.
-    """
+    """Get power info for a nonexistent device."""
     _, response = app.test_client.get(invalid_power_route_url)
-
-    assert response.status == 500
-
-    data = ujson.loads(response.text)
-
-    assert 'http_code' in data
-    assert 'error_id' in data
-    assert 'description' in data
-    assert 'timestamp' in data
-    assert 'context' in data
-
-    assert data['http_code'] == 500
-    assert data['error_id'] == errors.DEVICE_NOT_FOUND
+    utils.test_error_json(response, errors.DEVICE_NOT_FOUND)
 
 
 def test_power_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/base/test_test_route.py
+++ b/tests/integration/routes/base/test_test_route.py
@@ -1,28 +1,17 @@
-"""Test the 'synse.routes.base' Synse Server module's test route."""
+"""Test the 'synse.routes.base' module's test route."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
 import ujson
 
-from synse import factory
-
 test_url = '/synse/test'
-
-
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
 
 
 def test_test_endpoint_ok(app):
     """Test getting a good test response."""
     _, response = app.test_client.get(test_url)
-
     assert response.status == 200
 
     data = ujson.loads(response.text)
-
     assert 'status' in data
     assert 'timestamp' in data
 

--- a/tests/integration/routes/base/test_version_route.py
+++ b/tests/integration/routes/base/test_version_route.py
@@ -1,28 +1,19 @@
-"""Test the 'synse.routes.base' Synse Server module's version route."""
+"""Test the 'synse.routes.base' module's version route."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
 import ujson
 
-from synse import factory, version
+from synse import version
 
 version_url = '/synse/version'
-
-
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
 
 
 def test_version_endpoint_ok(app):
     """Test getting a good version response."""
     _, response = app.test_client.get(version_url)
-
     assert response.status == 200
 
     data = ujson.loads(response.text)
-
     assert 'version' in data
     assert 'api_version' in data
 

--- a/tests/integration/routes/core/test_config_route.py
+++ b/tests/integration/routes/core/test_config_route.py
@@ -1,34 +1,19 @@
-"""Test the 'synse.routes.core' Synse Server module's config route."""
+"""Test the 'synse.routes.core' module's config route."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
 import ujson
 
-from synse import config, factory
 from synse.version import __api_version__
 
 config_url = '/synse/{}/config'.format(__api_version__)
 
 
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
-
-
 def test_config_endpoint_ok(app):
-    """Test getting a good config response.
-
-    Details:
-        These are the final configurations for the application.
-        Check one by one to to make sure it return the right value.
-    """
+    """Get the Synse Server configuration."""
     _, response = app.test_client.get(config_url)
-
     assert response.status == 200
 
     data = ujson.loads(response.text)
-
     assert 'locale' in data
     assert 'pretty_json' in data
     assert 'logging' in data

--- a/tests/integration/routes/core/test_info_route.py
+++ b/tests/integration/routes/core/test_info_route.py
@@ -1,11 +1,9 @@
-"""Test the 'synse.routes.core' Synse Server module's info route."""
+"""Test the 'synse.routes.core' module's info route."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
-import ujson
-
-from synse import errors, factory
+from synse import errors
 from synse.version import __api_version__
+from tests import utils
 
 info_url = '/synse/{}/info'.format(__api_version__)
 invalid_rack_info_url = '{}/invalid-rack'.format(info_url)
@@ -13,33 +11,10 @@ invalid_board_info_url = '{}/invalid-board'.format(invalid_rack_info_url)
 invalid_device_info_url = '{}/invalid-device'.format(invalid_board_info_url)
 
 
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
-
-
 def test_rack_info_endpoint_invalid(app):
-    """Test getting a invalid rack info response.
-
-    Details:
-        In this case, rack is invalid.
-        The retuned error should be RACK_NOT_FOUND.
-    """
+    """Issue a request for a nonexistent rack."""
     _, response = app.test_client.get(invalid_rack_info_url)
-
-    assert response.status == 500
-
-    data = ujson.loads(response.text)
-
-    assert 'http_code' in data
-    assert 'error_id' in data
-    assert 'description' in data
-    assert 'timestamp' in data
-    assert 'context' in data
-
-    assert data['http_code'] == 500
-    assert data['error_id'] == errors.RACK_NOT_FOUND
+    utils.test_error_json(response, errors.RACK_NOT_FOUND)
 
 
 def test_rack_info_endpoint_post_not_allowed(app):
@@ -79,28 +54,13 @@ def test_rack_info_endpoint_options_not_allowed(app):
 
 
 def test_board_info_endpoint_invalid(app):
-    """Test getting a board info response.
+    """Issue a request for a nonexistent rack/board.
 
-    Details:
-        In this case, rack and board are invalid.
-        Since the rack is not valid in the first place,
-        it doesn't matter if the board is valid or not.
-        The returned error should still be RACK_NOT_FOUND.
+    While both board and rack do not exist, we get the RACK_NOT_FOUND
+    error because of the lookup order.
     """
     _, response = app.test_client.get(invalid_board_info_url)
-
-    assert response.status == 500
-
-    data = ujson.loads(response.text)
-
-    assert 'http_code' in data
-    assert 'error_id' in data
-    assert 'description' in data
-    assert 'timestamp' in data
-    assert 'context' in data
-
-    assert data['http_code'] == 500
-    assert data['error_id'] == errors.RACK_NOT_FOUND
+    utils.test_error_json(response, errors.RACK_NOT_FOUND)
 
 
 def test_board_info_endpoint_post_not_allowed(app):
@@ -140,28 +100,13 @@ def test_board_info_endpoint_options_not_allowed(app):
 
 
 def test_device_info_endpoint_invalid(app):
-    """Test getting a device info response.
+    """Issue a request for a nonexistent rack/board/device.
 
-    Details:
-        In this case, rack, board, device are invalid.
-        Since the rack is not valid in the first place,
-        it doesn't matter if the board is or device valid or not.
-        The returned error should still be RACK_NOT_FOUND.
+    While device, board, and rack do not exist, we get the RACK_NOT_FOUND
+    error because of the lookup order.
     """
     _, response = app.test_client.get(invalid_device_info_url)
-
-    assert response.status == 500
-
-    data = ujson.loads(response.text)
-
-    assert 'http_code' in data
-    assert 'error_id' in data
-    assert 'description' in data
-    assert 'timestamp' in data
-    assert 'context' in data
-
-    assert data['http_code'] == 500
-    assert data['error_id'] == errors.RACK_NOT_FOUND
+    utils.test_error_json(response, errors.RACK_NOT_FOUND)
 
 
 def test_device_info_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/core/test_plugins_route.py
+++ b/tests/integration/routes/core/test_plugins_route.py
@@ -1,29 +1,20 @@
-"""Test the 'synse.routes.core' Synse Server module's plugin route."""
+"""Test the 'synse.routes.core' module's plugin route."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
 import ujson
 
-from synse import factory
 from synse.version import __api_version__
 
 plugins_url = '/synse/{}/plugins'.format(__api_version__)
 
 
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
-
-
 def test_plugins_endpoint_ok(app):
     """Test getting a good plugins response."""
     _, response = app.test_client.get(plugins_url)
-
     assert response.status == 200
 
+    # since there is no plugin backend, we don't expect any plugins
     data = ujson.loads(response.text)
-
     assert len(data) == 0
 
 

--- a/tests/integration/routes/core/test_scan_route.py
+++ b/tests/integration/routes/core/test_scan_route.py
@@ -1,32 +1,24 @@
-"""Test the 'synse.routes.core' Synse Server module's scan route."""
+"""Test the 'synse.routes.core' module's scan route."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
 import ujson
 
-from synse import errors, factory
+from synse import errors
 from synse.version import __api_version__
+from tests import utils
 
 scan_url = '/synse/{}/scan'.format(__api_version__)
 invalid_rack_scan_url = '{}/invalid-rack'.format(scan_url)
 invalid_board_scan_url = '{}/invalid-board'.format(invalid_rack_scan_url)
 
 
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
-
-
 def test_scan_endpoint_ok(app):
     """Test getting a scan response.
 
-    Details:
-        Since the emulator plugin is not enabled,
-        there should not be any data for the rack.
+    Since the emulator plugin is not enabled, there should not
+    be any data for the rack.
     """
     _, response = app.test_client.get(scan_url)
-
     assert response.status == 200
 
     data = ujson.loads(response.text)
@@ -72,24 +64,11 @@ def test_scan_endpoint_options_not_allowed(app):
 def test_rack_scan_endpoint_invalid(app):
     """Test getting a invalid rack scan response.
 
-    Details:
-        There is no backend, so the scan will be empty. When
-        the scan is empty, we can't filter on racks/boards.
+    There is no plugin backend, so the scan will be empty. When
+    the scan is empty, we can't filter on racks/boards.
     """
     _, response = app.test_client.get(invalid_rack_scan_url)
-
-    assert response.status == 500
-
-    data = ujson.loads(response.text)
-
-    assert 'http_code' in data
-    assert 'error_id' in data
-    assert 'description' in data
-    assert 'timestamp' in data
-    assert 'context' in data
-
-    assert data['http_code'] == 500
-    assert data['error_id'] == errors.FAILED_SCAN_COMMAND
+    utils.test_error_json(response, errors.FAILED_SCAN_COMMAND)
 
 
 def test_rack_scan_endpoint_post_not_allowed(app):
@@ -131,24 +110,11 @@ def test_rack_scan_endpoint_options_not_allowed(app):
 def test_board_scan_endpoint_invalid(app):
     """Test getting a board scan response.
 
-    Details:
-        There is no backend, so the scan will be empty. When
-        the scan is empty, we can't filter on racks/boards.
+    There is no plugin backend, so the scan will be empty. When
+    the scan is empty, we can't filter on racks/boards.
     """
     _, response = app.test_client.get(invalid_board_scan_url)
-
-    assert response.status == 500
-
-    data = ujson.loads(response.text)
-
-    assert 'http_code' in data
-    assert 'error_id' in data
-    assert 'description' in data
-    assert 'timestamp' in data
-    assert 'context' in data
-
-    assert data['http_code'] == 500
-    assert data['error_id'] == errors.FAILED_SCAN_COMMAND
+    utils.test_error_json(response, errors.FAILED_SCAN_COMMAND)
 
 
 def test_board_scan_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/core/test_transaction_route.py
+++ b/tests/integration/routes/core/test_transaction_route.py
@@ -1,29 +1,17 @@
-"""Test the 'synse.routes.core' Synse Server module's transaction route."""
+"""Test the 'synse.routes.core' module's transaction route."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
-import ujson
-
-from synse import factory
+from synse import errors
 from synse.version import __api_version__
+from tests import utils
 
 invalid_transaction_url = '/synse/{}/transaction/invalid-id'.format(__api_version__)
-
-
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
 
 
 def test_transaction_endpoint_invalid(app):
     """Test getting a invalid transaction response."""
     _, response = app.test_client.get(invalid_transaction_url)
-
-    assert response.status == 500
-
-    # FIXME: Failed transaction id should return some kind of error message.
-    # Right now, it doesn't seem to have one
+    utils.test_error_json(response, errors.TRANSACTION_NOT_FOUND)
 
 
 def test_transaction_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/core/test_write_route.py
+++ b/tests/integration/routes/core/test_write_route.py
@@ -1,19 +1,13 @@
-"""Test the 'synse.routes.core' Synse Server module's write route."""
+"""Test the 'synse.routes.core' module's write route."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
 import ujson
 
-from synse import errors, factory
+from synse import errors
 from synse.version import __api_version__
+from tests import utils
 
 invalid_write_url = '/synse/{}/write/invalid-rack/invalid-board/invalid-device'.format(__api_version__)
-
-
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
 
 
 def test_write_invalid_endpoint_valid_data(app):
@@ -52,19 +46,7 @@ def test_write_invalid_endpoint_valid_data(app):
 
     for option, payload in valid_post_data.items():
         _, response = app.test_client.post(invalid_write_url, data=ujson.dumps(payload))
-
-        assert response.status == 500
-
-        response_data = ujson.loads(response.text)
-
-        assert 'http_code' in response_data
-        assert 'error_id' in response_data
-        assert 'description' in response_data
-        assert 'timestamp' in response_data
-        assert 'context' in response_data
-
-        assert response_data['http_code'] == 500
-        assert response_data['error_id'] == errors.DEVICE_NOT_FOUND
+        utils.test_error_json(response, errors.DEVICE_NOT_FOUND)
 
 
 def test_write_invalid_endpoint_invalid_data(app):
@@ -84,19 +66,7 @@ def test_write_invalid_endpoint_invalid_data(app):
     
     for option, payload in invalid_post_data.items():
         _, response = app.test_client.post(invalid_write_url, data=ujson.dumps(payload))
-
-        assert response.status == 500
-
-        response_data = ujson.loads(response.text)
-
-        assert 'http_code' in response_data
-        assert 'error_id' in response_data
-        assert 'description' in response_data
-        assert 'timestamp' in response_data
-        assert 'context' in response_data
-
-        assert response_data['http_code'] == 500
-        assert response_data['error_id'] == errors.INVALID_ARGUMENTS
+        utils.test_error_json(response, errors.INVALID_ARGUMENTS)
 
 
 def test_write_endpoint_post_not_allowed(app):

--- a/tests/unit/commands/test_read_command.py
+++ b/tests/unit/commands/test_read_command.py
@@ -116,7 +116,7 @@ def make_plugin(setup):
 
 
 @pytest.mark.asyncio
-async def test_read_command_no_device(plugin_dir):
+async def test_read_command_no_device():
     """Get a ReadResponse when the device doesn't exist."""
 
     # FIXME - it would be nice to use pytest.raises, but it seems like it isn't

--- a/tests/unit/commands/test_transaction_command.py
+++ b/tests/unit/commands/test_transaction_command.py
@@ -1,8 +1,6 @@
 """Test the 'synse.commands.transaction' Synse Server module."""
 # pylint: disable=redefined-outer-name,unused-argument,line-too-long
 
-import os
-import shutil
 
 import asynctest
 import grpc
@@ -14,23 +12,6 @@ from synse import errors, plugin
 from synse.commands.transaction import check_transaction
 from synse.proto.client import SynseInternalClient
 from synse.scheme.transaction import TransactionResponse
-
-
-@pytest.fixture(scope='module')
-def setup():
-    """Fixture to setup/teardown the module tests"""
-
-    # create a temp directory for test data
-    if not os.path.isdir('tmp'):
-        os.makedirs('tmp')
-
-    # create a dummy file as test data
-    open('tmp/foo', 'w').close()
-
-    yield
-
-    if os.path.isdir('tmp'):
-        shutil.rmtree('tmp')
 
 
 def mockgettransaction(transaction):
@@ -84,12 +65,12 @@ def mock_client_transaction_fail(monkeypatch):
 
 
 @pytest.fixture()
-def make_plugin(setup):
+def make_plugin():
     """Fixture to create and register a plugin for testing."""
 
     # make a dummy plugin for the tests to use
     if 'foo' not in plugin.Plugin.manager.plugins:
-        plugin.Plugin('foo', 'tmp/foo', 'unix')
+        plugin.Plugin('foo', 'localhost:9999', 'tcp')
 
     yield
 
@@ -131,6 +112,18 @@ async def test_transaction_command_grpc_err(mock_get_transaction, mock_client_tr
         await check_transaction('foo')
     except errors.SynseError as e:
         assert e.error_id == errors.FAILED_TRANSACTION_COMMAND
+
+
+@pytest.mark.asyncio
+async def test_transaction_command_no_transaction(clear_caches):
+    """Get a transaction that doesn't exist in the cache."""
+
+    # FIXME - it would be nice to use pytest.raises, but it seems like it isn't
+    # properly trapping the exception for further testing.
+    try:
+        await check_transaction('nonexistent')
+    except errors.SynseError as e:
+        assert e.error_id == errors.TRANSACTION_NOT_FOUND
 
 
 @pytest.mark.asyncio

--- a/tests/unit/commands/test_write_command.py
+++ b/tests/unit/commands/test_write_command.py
@@ -132,7 +132,7 @@ def make_plugin(setup):
 
 
 @pytest.mark.asyncio
-async def test_write_command_no_device(plugin_dir):
+async def test_write_command_no_device():
     """Get a WriteResponse when the device doesn't exist."""
 
     # FIXME - it would be nice to use pytest.raises, but it seems like it isn't

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,68 @@
+"""Test configuration for Synse Server unit tests.
+"""
+
+import os
+import shutil
+
+import pytest
+
+from synse import cache, config, const, plugin
+from synse.proto import client
+from tests import data_dir
+
+
+@pytest.fixture(scope='module', autouse=True)
+def tmp_dir():
+    """Fixture to create and remove the _tmp dir, used to hold test data."""
+    if not os.path.isdir(data_dir):
+        os.mkdir(data_dir)
+
+    yield
+    if os.path.isdir(data_dir):
+        shutil.rmtree(data_dir)
+
+
+@pytest.fixture(autouse=True)
+def clear_tmp_dir():
+    """Clear the _tmp directory of test data between tests."""
+    yield
+    for f in os.listdir(data_dir):
+        path = os.path.join(data_dir, f)
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            os.unlink(path)
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    """Fixture to reset all Synse Server state between tests."""
+
+    _old = const.SOCKET_DIR
+    const.SOCKET_DIR = data_dir
+
+    yield
+
+    # reset configuration
+    config.options = {}
+
+    # reset managed plugins
+    plugin.Plugin.manager.plugins = {}
+
+    # clear out the state of the client manager
+    client.SynseInternalClient._client_stubs = {}
+
+    # clear the environment
+    for k, _ in os.environ.items():
+        if k.startswith('SYNSE_'):
+            del os.environ[k]
+
+    # reset the socket directory
+    const.SOCKET_DIR = _old
+
+
+@pytest.fixture()
+async def clear_caches():
+    """Fixture to clear all caches before a test starts."""
+    await cache.clear_all_meta_caches()
+    await cache.clear_cache(cache.NS_TRANSACTION)

--- a/tests/unit/proto/test_client.py
+++ b/tests/unit/proto/test_client.py
@@ -78,18 +78,10 @@ def mock_transaction(req, timeout):
         state=0,
     )
 
-# --- Test Fixtures ---
-
-
-@pytest.fixture()
-def clear_state():
-    """Fixture to clear out the state of the client manager between tests."""
-    client.SynseInternalClient._client_stubs = {}
-
 # --- Test Cases ---
 
 
-def test_write_data(clear_state):
+def test_write_data():
     """Test initializing WriteData instances."""
 
     wd = client.WriteData()
@@ -109,7 +101,7 @@ def test_write_data(clear_state):
     assert wd.raw == [b'test']
 
 
-def test_write_data_to_grpc(clear_state):
+def test_write_data_to_grpc():
     """Convert a WriteData instance to its gRPC equivalent."""
 
     wd = client.WriteData(action='test', raw=[b'test'])
@@ -120,7 +112,7 @@ def test_write_data_to_grpc(clear_state):
     assert rpc.raw == [b'test']
 
 
-def test_get_client_exists(clear_state):
+def test_get_client_exists():
     """Get a client when the client exists."""
 
     c = client.SynseInternalClient('test-cli', 'localhost:5000', 'tcp')
@@ -131,7 +123,7 @@ def test_get_client_exists(clear_state):
     assert len(client.SynseInternalClient._client_stubs) == 1
 
 
-def test_get_client_does_not_exist(clear_state):
+def test_get_client_does_not_exist():
     """Get a client when it does not already exist."""
 
     assert len(client.SynseInternalClient._client_stubs) == 0
@@ -141,7 +133,7 @@ def test_get_client_does_not_exist(clear_state):
     assert len(client.SynseInternalClient._client_stubs) == 0
 
 
-def test_client_init(clear_state):
+def test_client_init():
     """Verify the client initializes as expected."""
 
     c = client.SynseInternalClient('test-cli', 'test-cli.sock', 'unix')
@@ -153,14 +145,14 @@ def test_client_init(clear_state):
     assert isinstance(c.stub, synse_grpc.InternalApiStub)
 
 
-def test_client_init_bad_mode(clear_state):
+def test_client_init_bad_mode():
     """Verify the client fails to initialize when a bad mode is provided."""
 
     with pytest.raises(errors.InvalidArgumentsError):
         client.SynseInternalClient('test-cli', 'test-cli.sock', 'foo')
 
 
-def test_client_read(clear_state):
+def test_client_read():
     """Test reading via the client."""
 
     c = client.SynseInternalClient('test', 'test.sock', 'unix')
@@ -173,7 +165,7 @@ def test_client_read(clear_state):
     assert isinstance(resp[0], synse_api.ReadResponse)
 
 
-def test_client_write(clear_state):
+def test_client_write():
     """Test writing via the client."""
 
     c = client.SynseInternalClient('test', 'test.sock', 'unix')
@@ -184,7 +176,7 @@ def test_client_write(clear_state):
     assert isinstance(resp, synse_api.Transactions)
 
 
-def test_client_metainfo(clear_state):
+def test_client_metainfo():
     """Test getting metainfo via the client."""
 
     c = client.SynseInternalClient('test', 'test.sock', 'unix')
@@ -197,7 +189,7 @@ def test_client_metainfo(clear_state):
     assert isinstance(resp[0], synse_api.MetainfoResponse)
 
 
-def test_client_transaction(clear_state):
+def test_client_transaction():
     """Test checking a transaction via the client."""
 
     c = client.SynseInternalClient('test', 'test.sock', 'unix')

--- a/tests/unit/routes/aliases/test_boot_target_route.py
+++ b/tests/unit/routes/aliases/test_boot_target_route.py
@@ -5,13 +5,13 @@
 import asynctest
 import pytest
 from sanic.response import HTTPResponse
-from tests import utils
 
 import synse.commands
 import synse.validate
-from synse import config, errors
+from synse import errors
 from synse.routes.aliases import boot_target_route
 from synse.scheme.base_response import SynseResponse
+from tests import utils
 
 
 def mockwritereturn(rack, board, device, data):
@@ -55,12 +55,6 @@ def mock_validate_device_type(monkeypatch):
     mock = asynctest.CoroutineMock(synse.validate.validate_device_type, side_effect=mockvalidatedevicetype)
     monkeypatch.setattr(synse.validate, 'validate_device_type', mock)
     return mock_validate_device_type
-
-
-@pytest.fixture()
-def no_pretty_json():
-    """Fixture to ensure basic JSON responses."""
-    config.options['pretty_json'] = False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/routes/aliases/test_fan_route.py
+++ b/tests/unit/routes/aliases/test_fan_route.py
@@ -5,13 +5,13 @@
 import asynctest
 import pytest
 from sanic.response import HTTPResponse
-from tests import utils
 
 import synse.commands
 import synse.validate
-from synse import config, errors
+from synse import errors
 from synse.routes.aliases import fan_route
 from synse.scheme.base_response import SynseResponse
+from tests import utils
 
 
 def mockwritereturn(rack, board, device, data):
@@ -55,12 +55,6 @@ def mock_validate_device_type(monkeypatch):
     mock = asynctest.CoroutineMock(synse.validate.validate_device_type, side_effect=mockvalidatedevicetype)
     monkeypatch.setattr(synse.validate, 'validate_device_type', mock)
     return mock_validate_device_type
-
-
-@pytest.fixture()
-def no_pretty_json():
-    """Fixture to ensure basic JSON responses."""
-    config.options['pretty_json'] = False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/routes/aliases/test_led_route.py
+++ b/tests/unit/routes/aliases/test_led_route.py
@@ -7,14 +7,14 @@ import pytest
 import ujson
 from sanic.response import HTTPResponse
 from synse_plugin import api
-from tests import utils
 
 import synse.commands
 import synse.validate
-from synse import config, errors
+from synse import errors
 from synse.routes.aliases import led_route
 from synse.scheme.base_response import SynseResponse
 from synse.scheme.write import WriteResponse
+from tests import utils
 
 
 def mockwritereturn(rack, board, device, data):
@@ -62,12 +62,6 @@ def mock_validate_device_type(monkeypatch):
     mock = asynctest.CoroutineMock(synse.validate.validate_device_type, side_effect=mockvalidatedevicetype)
     monkeypatch.setattr(synse.validate, 'validate_device_type', mock)
     return mock_validate_device_type
-
-
-@pytest.fixture()
-def no_pretty_json():
-    """Fixture to ensure basic JSON responses."""
-    config.options['pretty_json'] = False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/routes/aliases/test_power_route.py
+++ b/tests/unit/routes/aliases/test_power_route.py
@@ -5,13 +5,13 @@
 import asynctest
 import pytest
 from sanic.response import HTTPResponse
-from tests import utils
 
 import synse.commands
 import synse.validate
-from synse import config, errors
+from synse import errors
 from synse.routes.aliases import power_route
 from synse.scheme.base_response import SynseResponse
+from tests import utils
 
 
 def mockwritereturn(rack, board, device, data):
@@ -55,12 +55,6 @@ def mock_validate_device_type(monkeypatch):
     mock = asynctest.CoroutineMock(synse.validate.validate_device_type, side_effect=mockvalidatedevicetype)
     monkeypatch.setattr(synse.validate, 'validate_device_type', mock)
     return mock_validate_device_type
-
-
-@pytest.fixture()
-def no_pretty_json():
-    """Fixture to ensure basic JSON responses."""
-    config.options['pretty_json'] = False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/routes/core/test_config_route.py
+++ b/tests/unit/routes/core/test_config_route.py
@@ -6,7 +6,6 @@ import pytest
 from sanic.response import HTTPResponse
 
 import synse.commands
-from synse import config
 from synse.routes.core import config_route
 from synse.scheme.base_response import SynseResponse
 
@@ -24,12 +23,6 @@ def mock_config(monkeypatch):
     mock = asynctest.CoroutineMock(synse.commands.config, side_effect=mockreturn)
     monkeypatch.setattr(synse.commands, 'config', mock)
     return mock_config
-
-
-@pytest.fixture()
-def no_pretty_json():
-    """Fixture to ensure basic JSON responses."""
-    config.options['pretty_json'] = False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/routes/core/test_info_route.py
+++ b/tests/unit/routes/core/test_info_route.py
@@ -6,7 +6,6 @@ import pytest
 from sanic.response import HTTPResponse
 
 import synse.commands
-from synse import config
 from synse.routes.core import info_route
 from synse.scheme.base_response import SynseResponse
 
@@ -24,12 +23,6 @@ def mock_info(monkeypatch):
     mock = asynctest.CoroutineMock(synse.commands.info, side_effect=mockreturn)
     monkeypatch.setattr(synse.commands, 'info', mock)
     return mock_info
-
-
-@pytest.fixture()
-def no_pretty_json():
-    """Fixture to ensure basic JSON responses."""
-    config.options['pretty_json'] = False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/routes/core/test_plugins_route.py
+++ b/tests/unit/routes/core/test_plugins_route.py
@@ -6,7 +6,6 @@ import pytest
 from sanic.response import HTTPResponse
 
 import synse.commands
-from synse import config
 from synse.routes.core import plugins_route
 from synse.scheme.base_response import SynseResponse
 
@@ -24,12 +23,6 @@ def mock_plugins(monkeypatch):
     mock = asynctest.CoroutineMock(synse.commands.get_plugins, side_effect=mockreturn)
     monkeypatch.setattr(synse.commands, 'get_plugins', mock)
     return mock_plugins
-
-
-@pytest.fixture()
-def no_pretty_json():
-    """Fixture to ensure basic JSON responses."""
-    config.options['pretty_json'] = False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/routes/core/test_read_route.py
+++ b/tests/unit/routes/core/test_read_route.py
@@ -6,7 +6,6 @@ import pytest
 from sanic.response import HTTPResponse
 
 import synse.commands
-from synse import config
 from synse.routes.core import read_route
 from synse.scheme.base_response import SynseResponse
 
@@ -24,12 +23,6 @@ def mock_read(monkeypatch):
     mock = asynctest.CoroutineMock(synse.commands.read, side_effect=mockreturn)
     monkeypatch.setattr(synse.commands, 'read', mock)
     return mock_read
-
-
-@pytest.fixture()
-def no_pretty_json():
-    """Fixture to ensure basic JSON responses."""
-    config.options['pretty_json'] = False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/routes/core/test_scan_route.py
+++ b/tests/unit/routes/core/test_scan_route.py
@@ -4,12 +4,11 @@
 import asynctest
 import pytest
 from sanic.response import HTTPResponse
-from tests import utils
 
 import synse.commands
-from synse import config
 from synse.routes.core import scan_route
 from synse.scheme.base_response import SynseResponse
+from tests import utils
 
 
 def mockreturn(rack, board, force):
@@ -25,12 +24,6 @@ def mock_scan(monkeypatch):
     mock = asynctest.CoroutineMock(synse.commands.scan, side_effect=mockreturn)
     monkeypatch.setattr(synse.commands, 'scan', mock)
     return mock_scan
-
-
-@pytest.fixture()
-def no_pretty_json():
-    """Fixture to ensure basic JSON responses."""
-    config.options['pretty_json'] = False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/routes/core/test_transaction_route.py
+++ b/tests/unit/routes/core/test_transaction_route.py
@@ -6,7 +6,6 @@ import pytest
 from sanic.response import HTTPResponse
 
 import synse.commands
-from synse import config
 from synse.routes.core import transaction_route
 from synse.scheme.base_response import SynseResponse
 
@@ -24,12 +23,6 @@ def mock_transaction(monkeypatch):
     mock = asynctest.CoroutineMock(synse.commands.check_transaction, side_effect=mockreturn)
     monkeypatch.setattr(synse.commands, 'check_transaction', mock)
     return mock_transaction
-
-
-@pytest.fixture()
-def no_pretty_json():
-    """Fixture to ensure basic JSON responses."""
-    config.options['pretty_json'] = False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/routes/core/test_write_route.py
+++ b/tests/unit/routes/core/test_write_route.py
@@ -4,13 +4,12 @@
 import asynctest
 import pytest
 from sanic.response import HTTPResponse
-from tests import utils
 
 import synse.commands
-from synse import config
 from synse.errors import InvalidJsonError, SynseError
 from synse.routes.core import write_route
 from synse.scheme.base_response import SynseResponse
+from tests import utils
 
 
 def mockreturn(rack, board, device, data):
@@ -26,12 +25,6 @@ def mock_write(monkeypatch):
     mock = asynctest.CoroutineMock(synse.commands.write, side_effect=mockreturn)
     monkeypatch.setattr(synse.commands, 'write', mock)
     return mock_write
-
-
-@pytest.fixture()
-def no_pretty_json():
-    """Fixture to ensure basic JSON responses."""
-    config.options['pretty_json'] = False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/scheme/test_config_scheme.py
+++ b/tests/unit/scheme/test_config_scheme.py
@@ -1,26 +1,13 @@
 """Test the 'synse.scheme.config' Synse Server module."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
-
 from synse import config
 from synse.scheme.config import ConfigResponse
 
 
-@pytest.fixture()
-def set_config():
-    """Fixture to set the global Synse Server config to some test values."""
-    config.options = {'debug': False, 'pretty_json': True, 'some_key': 1}
-
-
-@pytest.fixture()
-def set_config_hidden():
-    """Fixture to set the global Synse Server config to some test values, with one hidden."""
-    config.options = {'debug': False, 'pretty_json': True, '_some_key': 1}
-
-
-def test_config_scheme(set_config):
+def test_config_scheme():
     """Test that the config scheme matches the expected."""
+    config.options = {'debug': False, 'pretty_json': True, 'some_key': 1}
 
     response_scheme = ConfigResponse()
 
@@ -33,8 +20,9 @@ def test_config_scheme(set_config):
     }
 
 
-def test_config_scheme_hidden_value(set_config_hidden):
+def test_config_scheme_hidden_value():
     """Test that the config scheme matches the expected when a value is marked as hidden."""
+    config.options = {'debug': False, 'pretty_json': True, '_some_key': 1}
 
     response_scheme = ConfigResponse()
 

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -1,16 +1,9 @@
 """Test the 'synse.factory' Synse Server module."""
 # pylint: disable=redefined-outer-name,unused-argument
 
-import pytest
 import ujson
 
 from synse import config, errors, factory
-
-
-@pytest.fixture()
-def app():
-    """Fixture to get a Synse Server application instance."""
-    yield factory.make_app()
 
 
 def test_make_app():

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -7,15 +7,6 @@ import pytest
 
 from synse import config, i18n
 
-# --- Helper Functions ---
-
-def change_config_locale(value):
-    """Helper method to change the locale key in synse.config.options.
-    """
-    config.options['locale'] = value
-
-
-# --- Mock Methods ---
 
 def mock_get_translator():
     """Used to replace i18n._get_translator().
@@ -23,8 +14,6 @@ def mock_get_translator():
     """
     return gettext.translation('', '', fallback=True)
 
-
-# --- Test Fixtures ---
 
 @pytest.fixture()
 def clean_i18n():
@@ -71,12 +60,12 @@ def test_i18n_init(clean_i18n):
 def test_get_language_none():
     """Tests that i18n._get_language() returns 'en_US' when config has None as locale key.
     """
-    change_config_locale(None)
+    config.options['locale'] = None
     assert i18n._get_language() == 'en_US'
 
 
 def test_get_language_str():
     """Tests that i18n._get_language() returns the correct config key.
     """
-    change_config_locale('this is a string')
+    config.options['locale'] = 'this is a string'
     assert i18n._get_language() == 'this is a string'

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -57,13 +57,6 @@ def patch_metainfo(monkeypatch):
     return patch_metainfo
 
 
-@pytest.fixture()
-async def clear_caches():
-    """Fixture to clear all caches before a test starts."""
-    await cache.clear_all_meta_caches()
-    await cache.clear_cache(cache.NS_TRANSACTION)
-
-
 @pytest.mark.asyncio
 async def test_validate_device_type(patch_metainfo, clear_caches):
     """Test successfully validating a device."""
@@ -78,7 +71,7 @@ async def test_validate_device_type(patch_metainfo, clear_caches):
 
 
 @pytest.mark.asyncio
-async def test_validate_device_type_no_device(plugin_dir):
+async def test_validate_device_type_no_device():
     """Test validating a device when the specified device doesn't exist."""
     with pytest.raises(errors.DeviceNotFoundError):
         await validate.validate_device_type('thermistor', 'foo', 'bar', 'baz')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,3 +27,20 @@ def make_request(url, data=None):
         r.body = ujson.dumps(data)
 
     return r
+
+
+def test_error_json(response, error_id, status_code=500):
+    """Test utility for validating Synse Server error JSON responses."""
+
+    assert response.status == status_code
+
+    response_data = ujson.loads(response.text)
+
+    assert 'http_code' in response_data
+    assert 'error_id' in response_data
+    assert 'description' in response_data
+    assert 'timestamp' in response_data
+    assert 'context' in response_data
+
+    assert response_data['http_code'] == status_code
+    assert response_data['error_id'] == error_id


### PR DESCRIPTION
**Review Deadline**: whenever

## Summary
this PR does _a lot_ of cleanup around tests. it consolidates fixtures which had duplicate definitions all over the place. it standardizes on a test data directory (~/_tmp_test) that is created and cleaned up during testing.

It also fixes a few bugs with some tests and a bug in the code where invalid transaction ids weren't handled correctly. Some of the reason this bug was missed before was because the 'fixture soup' we had made it seem like that case was covered, but it wasn't actually.

with all these changes, I found that unit and integration tests ran slightly faster on my machine. they are both already fast, so the difference doesn't *really* matter, but still nice all the same.

## Related Issues
- fixes #51 
- fixes #57 
