### PR TITLE
docker default and slim builds

### DIFF
--- a/.dockerignore.default
+++ b/.dockerignore.default
@@ -1,3 +1,11 @@
+#
+# .dockerignore.default
+#
+# The dockerignore file used for default Synse Server image builds.
+# By default, Synse Server includes the emulator. For a version of
+# Synse Server without the emulator, use the 'slim' build.
+#
+
 # JetBrains (PyCharm, WebStorm, etc.)
 .idea
 *.iws

--- a/.dockerignore.slim
+++ b/.dockerignore.slim
@@ -1,0 +1,61 @@
+#
+# .dockerignore.slim
+#
+# The dockerignore file used for slim Synse Server image builds.
+# The slim build of Synse Server does not include the emulator.
+# For a version of Synse Server with the emulator, use the standard
+# build.
+#
+
+# Emulator
+emulator/
+
+# JetBrains (PyCharm, WebStorm, etc.)
+.idea
+*.iws
+.idea_modules
+
+# Linux
+*~
+.directory
+.Trash-*
+**/packages
+
+# OSX
+.DS_Store
+._*
+.TemporaryItems
+.Trashes
+
+# Vagrant
+.vagrant
+
+# Git
+.git
+.gitignore
+
+# Python
+*.py[cod]
+**/__pycache__
+**/.tox
+.pep8
+
+# Logs
+logs/
+*.log
+
+# Docker
+Dockerfile.*
+**/*.dockerfile
+
+# Docs
+docs/
+**/*.md
+**/*.rst
+
+# Images
+**/*.png
+
+# Test Artifacts
+prof/
+results/

--- a/bin/synse.sh
+++ b/bin/synse.sh
@@ -78,12 +78,14 @@ function -v {
 #   start the background process emulator using the emulator
 #   configurations found in /synse/synse/emulator/config
 function enable-emulator {
-    (cd emulator ; PLUGIN_DEVICE_CONFIG=config ./emulator 1>&2 &)
-
-    # FIXME - this sleep is just added in for safety to make sure that
-    # the emulator, if started, has enough time to start up and create
-    # the socket that synse will use to communicate with it.
-    sleep 1
+    if [ -d emulator ]; then
+        (cd emulator ; PLUGIN_DEVICE_CONFIG=config ./emulator 1>&2 &)
+    else
+        echo "This Synse Server image does not contain the emulator."
+        echo "Try using a non 'slim' Synse Server image for emulator"
+        echo "support."
+        exit 1
+    fi
 }
 
 


### PR DESCRIPTION
**Review Deadline**: --

## Summary
builds a default image (w/ emulator) and slim image (sans emulator)

## Related Issues
- fixes #64 

## Notes
```
REPOSITORY                             TAG                 IMAGE ID            CREATED             SIZE
vaporio/synse-server                   2.0.0-slim          123b94642b2d        4 minutes ago       236MB
vaporio/synse-server                   slim                123b94642b2d        4 minutes ago       236MB
vaporio/synse-server                   2.0.0               fc844989bef8        4 minutes ago       251MB
vaporio/synse-server                   eedf55e             fc844989bef8        4 minutes ago       251MB
vaporio/synse-server                   latest              fc844989bef8        4 minutes ago       251MB
```