### PR TITLE
add info about supported python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ run it with its built-in emulator.
     ```
 
 ### Python Package
+
+> **Note**
+>
+> Synse Server is developed and tested on Python 3.6. It may run on other Python 3 versions,
+> but there is no guarantee or active support for anything other than Python 3.6. Version
+> compatibility contributions are welcome.
+
 TODO
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
     url=synse.__url__,
     author=synse.__author__,
     author_email=synse.__author_email__,
-    license='GPL v2.0',
+    license='GNU General Public License v2.0',
+    python_requires='3.6',
     packages=find_packages(),
     zip_safe=False
 )


### PR DESCRIPTION
**Review Deadline**: --

## Summary
makes note that Synse Server currently only supports Python 3.6

## Related Issues
- fixes #34 