### PR TITLE
add lock route, cleanup some error messages

### DIFF
--- a/synse/const.py
+++ b/synse/const.py
@@ -9,22 +9,60 @@ TYPE_LED = 'led'
 TYPE_FAN = 'fan'
 TYPE_SYSTEM = 'system'
 TYPE_POWER = 'power'
+TYPE_LOCK = 'lock'
 
 
-# LED states
+# LED state definitions
 LED_ON = 'on'
 LED_OFF = 'off'
 LED_BLINK = 'blink'
 LED_STEADY = 'steady'
-LED_NO_OVERRIDE = 'no_override'
+
+# all LED states
+led_states = (
+    LED_ON,
+    LED_OFF
+)
+
+# all LED blink states
+led_blink_states = (
+    LED_BLINK,
+    LED_STEADY
+)
 
 
-# power actions
+# Power action definitions
 PWR_ON = 'on'
 PWR_OFF = 'off'
 PWR_CYCLE = 'cycle'
 
+# all power actions
+power_actions = (
+    PWR_ON,
+    PWR_OFF,
+    PWR_CYCLE
+)
 
-# supported boot targets
+
+# Supported boot target definitions
 BT_HDD = 'hdd'
 BT_PXE = 'pxe'
+
+# all boot targets
+boot_targets = (
+    BT_HDD,
+    BT_PXE
+)
+
+
+# Lock action definitions
+LOCK_LOCK = 'lock'
+LOCK_UNLOCK = 'unlock'
+LOCK_MUNLOCK = 'munlock'  # momentary unlock
+
+# all lock actions
+lock_actions = (
+    LOCK_LOCK,
+    LOCK_UNLOCK,
+    LOCK_MUNLOCK
+)

--- a/synse/routes/aliases.py
+++ b/synse/routes/aliases.py
@@ -225,7 +225,7 @@ async def boot_target_route(request, rack, board, device):
 
 
 @bp.route('/lock/<rack>/<board>/<device>')
-async def lock_route(request, rack, board, device):
+async def lock_route(request, rack, board, device): # pylint: disable=unused-argument
     """Endpoint to read/write lock device data.
 
     If no lock action is specified through the request parameters,

--- a/synse/routes/aliases.py
+++ b/synse/routes/aliases.py
@@ -241,28 +241,30 @@ async def lock_route(request, rack, board, device):
     Returns:
         sanic.response.HTTPResponse: The endpoint response.
     """
-    await validate.validate_device_type(const.TYPE_LOCK, rack, board, device)
-
-    param_action = request.raw_args.get('action')
-
-    # if a request parameter is specified, this will translate to a
-    # write request.
-    if param_action is not None:
-        # validate the values of the action
-        if param_action not in const.lock_actions:
-            raise errors.InvalidArgumentsError(
-                gettext('Invalid lock action "{}". Must be one of: {}').format(
-                    param_action, const.lock_actions)
-            )
-
-        data = {
-            'action': param_action
-        }
-        transaction = await commands.write(rack, board, device, data)
-        return transaction.to_json()
-
-    # if no request parameter is specified, this will translate to a
-    # read request.
-    else:
-        reading = await commands.read(rack, board, device)
-        return reading.to_json()
+    # FIXME - error out until a lock backend is actually implemented
+    return errors.SynseError('Endpoint not yet implemented.')
+    # await validate.validate_device_type(const.TYPE_LOCK, rack, board, device)
+    #
+    # param_action = request.raw_args.get('action')
+    #
+    # # if a request parameter is specified, this will translate to a
+    # # write request.
+    # if param_action is not None:
+    #     # validate the values of the action
+    #     if param_action not in const.lock_actions:
+    #         raise errors.InvalidArgumentsError(
+    #             gettext('Invalid lock action "{}". Must be one of: {}').format(
+    #                 param_action, const.lock_actions)
+    #         )
+    #
+    #     data = {
+    #         'action': param_action
+    #     }
+    #     transaction = await commands.write(rack, board, device, data)
+    #     return transaction.to_json()
+    #
+    # # if no request parameter is specified, this will translate to a
+    # # read request.
+    # else:
+    #     reading = await commands.read(rack, board, device)
+    #     return reading.to_json()


### PR DESCRIPTION
**Review Deadline**: --

## Summary
adds the 'lock' alias route to v2.0

This is just the route - no tests yet since I need a clearer picture of how the backend plugin for this will look. think of this as more of a stub. will open a separate issue to add in tests for this.

this also fixes some lingering FIXMEs regarding adding more info to an error message.

## Related Issues
- fixes #35 

