### PR TITLE
fix bug in python_requires formatting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author=synse.__author__,
     author_email=synse.__author_email__,
     license='GNU General Public License v2.0',
-    python_requires='3.6',
+    python_requires='==3.6',
     packages=find_packages(),
     zip_safe=False
 )


### PR DESCRIPTION
**Review Deadline**: -- 

## Summary
fixes setup.py's python requirement syntax which caused the error:
```
 ---> 4e4af8b11a8e
Step 8/9 : RUN python setup.py install
 ---> Running in 38b73b2e55ad
error in synse setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '3.6'
The command '/bin/sh -c python setup.py install' returned a non-zero code: 1
make: *** [docker-default] Error 1
```