### PR TITLE
use transaction cache ttl of 300s

### DIFF
--- a/synse/cache.py
+++ b/synse/cache.py
@@ -86,15 +86,14 @@ async def add_transaction(transaction_id, context, plugin_name):
     Returns:
         bool: True if successful; False otherwise.
     """
-    # TODO (etd): add TTL to the transactions. TBD where this timeout is
-    # defined. Likely check the config for a value - if not there, use some
-    # default. #397
+    ttl = config.options.get('cache', {}).get('transaction', {}).get('ttl', None)
     return await transaction_cache.set(
         transaction_id,
         {
             'plugin': plugin_name,
             'context': context
-        }
+        },
+        ttl=ttl
     )
 
 

--- a/synse/config.py
+++ b/synse/config.py
@@ -120,7 +120,7 @@ def load_default_configs():
                 'ttl': 20
             },
             'transaction': {
-                'ttl': 20
+                'ttl': 300  # five minutes
             }
         },
         'grpc': {

--- a/tests/integration/routes/core/test_config_route.py
+++ b/tests/integration/routes/core/test_config_route.py
@@ -23,7 +23,7 @@ def test_config_endpoint_ok(app):
     assert data['locale'] == 'en_US'
     assert data['pretty_json'] == False
     assert data['logging'] == 'info'
-    assert data['cache'] == {'meta': {'ttl': 20}, 'transaction': {'ttl': 20}}
+    assert data['cache'] == {'meta': {'ttl': 20}, 'transaction': {'ttl': 300}}
     assert data['grpc'] == {'timeout': 3}
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -52,7 +52,7 @@ def test_load_default_configs():
                 'ttl': 20
             },
             'transaction': {
-                'ttl': 20
+                'ttl': 300
             }
         },
         'grpc': {


### PR DESCRIPTION
**Review Deadline**: --

## Summary
Uses the configured transaction cache TTL for transaction entries. Bump up the TTL from 20s to 300s.

## Related Issues
- fixes #41 
