### PR TITLE
update to temporary fan_sensors route

### DIFF
--- a/synse/commands/fan_sensors.py
+++ b/synse/commands/fan_sensors.py
@@ -45,8 +45,7 @@ async def fan_sensors():
                 resp = await read(rack, board, device)
             except Exception as e:
                 logger.warning('Failed to get reading for {}-{}-{} for fan_sensors {}.'.format(
-                    rack, board, device, e)
-                )
+                    rack, board, device, e))
             else:
                 readings.append(resp.data)
 

--- a/synse/commands/fan_sensors.py
+++ b/synse/commands/fan_sensors.py
@@ -2,7 +2,7 @@
 """
 
 from synse import cache
-from synse.commands import read
+from synse.commands.read import read
 from synse.log import logger
 
 
@@ -41,7 +41,13 @@ async def fan_sensors():
             board = v.location.board
             device = v.uid
 
-            resp = await read(rack, board, device)
-            readings.append(resp.data)
+            try:
+                resp = await read(rack, board, device)
+            except Exception as e:
+                logger.warning('Failed to get reading for {}-{}-{} for fan_sensors {}.'.format(
+                    rack, board, device, e)
+                )
+            else:
+                readings.append(resp.data)
 
     return readings


### PR DESCRIPTION
**Review Deadline**: --

## Summary
the `fan_sensors` route was failing on deployments where 'spare' devices were set in the config because it had no readings for those configured devices. 

this update:
- fixes a namespacing bug
- makes it so that if a device read fails, we just exclude that device from the return result