### PR TITLE
make parsing config files optional

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ grpcio>=1.8.6
 pyyaml>=3.12
 sanic>=0.7.0
 synse-plugin==0.0.3
-bison>=0.0.3
+bison>=0.0.4

--- a/synse/factory.py
+++ b/synse/factory.py
@@ -32,7 +32,7 @@ def make_app():
     config.options.env_prefix = 'SYNSE'
     config.options.auto_env = True
 
-    config.options.parse()
+    config.options.parse(requires_cfg=False)
     config.options.validate()
 
     # set up application logging


### PR DESCRIPTION
**Review Deadline**:  --

## Summary
Since we do not require config files for synse server (e.g. we can use the defaults/env to provide sufficient configuration), we should make the config files non-required when parsing and unifying the application configuration.