### PR TITLE
add /transaction route to list all active transactions

### DIFF
--- a/synse/commands/transaction.py
+++ b/synse/commands/transaction.py
@@ -5,19 +5,30 @@ import grpc
 
 from synse import cache, errors, plugin
 from synse.i18n import gettext
-from synse.scheme.transaction import TransactionResponse
+from synse.scheme import transaction as scheme
 
 
 async def check_transaction(transaction_id):
     """The handler for the Synse Server "transaction" API command.
 
     Args:
-        transaction_id (str): The id of the transaction to check.
+        transaction_id (str|None): The id of the transaction to check. If
+            the ID is None, a list of all transactions currently in the
+            cache is returned.
 
     Returns:
         TransactionResponse: The "transaction" response scheme model.
     """
+    # if we are not given a transaction ID, then we want to return
+    # the list of all actively tracked transactions.
+    if transaction_id is None:
+        tkeys = cache.transaction_cache._cache.keys()
+        # keys in the cache are prepended with 'transaction', so here we get all
+        # keys with that prefix and strip the prefix.
+        transaction_ids = [k[11:] for k in tkeys if k.startswith('transaction')]
+        return scheme.TransactionListResponse(transaction_ids)
 
+    # otherwise, get the specified transaction
     transaction = await cache.get_transaction(transaction_id)
     if not transaction:
         raise errors.TransactionNotFoundError(
@@ -51,4 +62,4 @@ async def check_transaction(transaction_id):
     except grpc.RpcError as ex:
         raise errors.FailedTransactionCommandError(str(ex)) from ex
 
-    return TransactionResponse(transaction_id, context, resp)
+    return scheme.TransactionResponse(transaction_id, context, resp)

--- a/synse/routes/core.py
+++ b/synse/routes/core.py
@@ -102,8 +102,9 @@ async def write_route(request, rack, board, device):
     return response.to_json()
 
 
+@bp.route('/transaction')
 @bp.route('/transaction/<transaction_id>')
-async def transaction_route(request, transaction_id):
+async def transaction_route(request, transaction_id=None):
     """Check the status of a write transaction.
 
     Args:

--- a/synse/scheme/transaction.py
+++ b/synse/scheme/transaction.py
@@ -48,3 +48,23 @@ class TransactionResponse(SynseResponse):
             'updated': write_response.updated,
             'message': write_response.message
         }
+
+
+class TransactionListResponse(SynseResponse):
+    """A TransactionListResponse is the response data for Synse Server's
+    'list transactions' action.
+
+    Response Example:
+        [
+            "b7jl0b2un4a154rn9u4g",
+            "b7jl0b2un4a154rn9u5a",
+            "b7jl0b2un4a154rn9ib2",
+        ]
+
+    Args:
+        transactions (list[str]): A list of the transaction ids.
+    """
+
+    def __init__(self, transactions):
+        """Constructor for the TransactionListResponse class."""
+        self.data = transactions

--- a/tests/unit/scheme/test_transaction_scheme.py
+++ b/tests/unit/scheme/test_transaction_scheme.py
@@ -35,7 +35,12 @@ def test_transaction_scheme():
 
 
 def test_transaction_list_scheme():
-    """Test that the transaction list scheme matches the expected."""
+    """Test that the transaction list scheme matches the expected.
+
+    Here, the TransactionListResponse just sets the data its given
+    (a list of string) to its `data` field, so we just check that
+    the data field is set.
+    """
     ids = [
         'abcdefg',
         'hijklmn',

--- a/tests/unit/scheme/test_transaction_scheme.py
+++ b/tests/unit/scheme/test_transaction_scheme.py
@@ -2,7 +2,8 @@
 
 from synse_plugin import api
 
-from synse.scheme.transaction import TransactionResponse
+from synse.scheme.transaction import (TransactionListResponse,
+                                      TransactionResponse)
 
 
 def test_transaction_scheme():
@@ -31,3 +32,17 @@ def test_transaction_scheme():
         'updated': 'november',
         'message': ''
     }
+
+
+def test_transaction_list_scheme():
+    """Test that the transaction list scheme matches the expected."""
+    ids = [
+        'abcdefg',
+        'hijklmn',
+        'opqrstu',
+        'vwxyz',
+        '12345'
+    ]
+
+    response_scheme = TransactionListResponse(ids)
+    assert response_scheme.data == ids


### PR DESCRIPTION
**Review Deadline**: --

## Summary
adds in the `/transaction` endpoint to list all of the active transactions in the cache.

## Related Issues
- https://github.com/vapor-ware/synse-cli/issues/133
- fixes #42 