### PR TITLE
Read response updates

### DIFF
--- a/synse/commands/read.py
+++ b/synse/commands/read.py
@@ -38,7 +38,6 @@ async def read(rack, board, device):
 
     try:
         # perform a gRPC read on the device's managing plugin
-        # FIXME (etd) - do we need to iterate here? the client already does this...
         read_data = [r for r in _plugin.client.read(rack, board, device)]
     except grpc.RpcError as ex:
 

--- a/synse/commands/read.py
+++ b/synse/commands/read.py
@@ -1,7 +1,11 @@
 """Command handler for the `read` route.
 """
+# pylint: disable=line-too-long
+
+from datetime import datetime, timezone
 
 import grpc
+from synse_plugin import api
 
 from synse import cache, errors, plugin
 from synse.i18n import gettext
@@ -20,16 +24,13 @@ async def read(rack, board, device):
     Returns:
         ReadResponse: The "read" response scheme model.
     """
-    # FIXME: clean up logging
-    logger.debug(gettext('>> READ cmd'))
-
     # lookup the known info for the specified device
     plugin_name, dev = await cache.get_device_meta(rack, board, device)
-    logger.debug(gettext('  |- got device: {}').format(dev))
+    logger.debug(gettext('Device {} is managed by plugin {}').format(device, plugin_name))
 
     # get the plugin context for the device's specified protocol
     _plugin = plugin.get_plugin(plugin_name)
-    logger.debug(gettext('  |- got plugin: {}').format(_plugin))
+    logger.debug(gettext('Got plugin: {}').format(_plugin))
     if not _plugin:
         raise errors.PluginNotFoundError(
             gettext('Unable to find plugin named "{}" to read.').format(plugin_name)
@@ -37,11 +38,64 @@ async def read(rack, board, device):
 
     try:
         # perform a gRPC read on the device's managing plugin
+        # FIXME (etd) - do we need to iterate here? the client already does this...
         read_data = [r for r in _plugin.client.read(rack, board, device)]
     except grpc.RpcError as ex:
-        raise errors.FailedReadCommandError(str(ex)) from ex
 
-    logger.debug(gettext('  |- read results: {}').format(read_data))
+        # FIXME (etd) - this isn't the nicest way of doing this check.
+        # this string is returned from the SDK, and its not likely to change
+        # anytime soon, so this is "safe" for now, but we should see if there
+        # is a better way to check this other than comparing strings..
+        if hasattr(ex, 'code') and hasattr(ex, 'details'):
+            if grpc.StatusCode.NOT_FOUND == ex.code() and 'no readings found' in ex.details().lower():
+
+                # Currently, in the SDK, there are three different behaviors for
+                # devices that do not have readings. Either (a). "null" is returned,
+                # (b). an empty string ("") is returned, or (c). a gRPC error is
+                # returned with the NOT_FOUND status code. Cases (a) and (b) are
+                # handled in the ReadResponse initialization (below). This block
+                # handles case (c).
+                #
+                # The reason for the difference between (a) and (b) is just one
+                # of implementation. The empty string is the default value for the
+                # gRPC read response, but sometimes it is useful to have an explict
+                # value set to make things easier to read.
+                #
+                # The difference between those and (c) is more distinct. (c) should
+                # only happen when a configured device is not being read from at all.
+                # Essentially, (c) is the fallback for when device-specific handlers
+                # fail to read a configured device.
+                #
+                # To summarize:
+                #   (a), (b)
+                #       A device is configured and the plugin's device handlers
+                #       can operate on the device. This indicates that the plugin
+                #       is working, but the device could be failing or disconnected.
+                #
+                #   (c)
+                #       A device is configured, but the plugin's device handler
+                #       can not (or is not) able to operate on the device. This
+                #       could indicate either a plugin configuration error or
+                #       an error with the plugin logic itself.
+
+                # Create empty readings for each of the device's readings.
+                logger.warning(
+                    'Read for {}/{}/{} returned gRPC "no readings found". Will '
+                    'apply None as reading value. Note that this response might '
+                    'indicate plugin error/misconfiguration.'.format(rack, board, device))
+                read_data = []
+                local_time = datetime.now(timezone.utc).astimezone()
+                for output in dev.output:
+                    read_data.append(
+                        api.ReadResponse(
+                            timestamp=local_time.isoformat(),
+                            type=output.type,
+                            value='',
+                        )
+                    )
+        else:
+            raise errors.FailedReadCommandError(str(ex)) from ex
+
     return ReadResponse(
         device=dev,
         readings=read_data

--- a/synse/errors.py
+++ b/synse/errors.py
@@ -1,7 +1,7 @@
 """Error definitions for Synse Server.
 """
 
-from sanic.exceptions import ServerError
+from sanic.exceptions import InvalidUsage, NotFound, ServerError
 
 # Not Found type errors
 DEVICE_NOT_FOUND = 4000
@@ -33,119 +33,180 @@ INVALID_DEVICE_TYPE = 3003
 UNKNOWN = 0
 
 
-class SynseError(ServerError):
-    """General error raised within Synse Server.
-
-    Everything that raises an exception within Synse Server should ultimately
-    propagate this (or a subclass of this) up to the route handler. There, it
-    will propagate up through Sanic handling and will result in a 500 error
-    response with JSON.
-    """
+class SynseError(Exception):
+    """The base exception class for all errors raised by Synse Server."""
 
     def __init__(self, message, error_id=None):
         super(SynseError, self).__init__(message)
         self.error_id = UNKNOWN if error_id is None else error_id
 
 
-class InvalidArgumentsError(SynseError):
+class SynseServerError(ServerError, SynseError):
+    """The base class for all HTTP 500 errors raised by Synse Server.
+
+    All errors that will ultimately issue an HTTP 500 response to the
+    caller should either use this class or a subclass of this class.
+    Doing so will allow the response to have a JSON payload that
+    provides context for the error.
+
+    In general Synse Server 500 errors are returned when there is an
+    unrecoverable error when trying to fulfill a request, e.g. unable
+    to complete a command.
+    """
+
+    def __init__(self, message, error_id=None):
+        ServerError.__init__(self, message)
+        SynseError.__init__(self, message, error_id)
+
+
+class SynseNotFoundError(NotFound, SynseError):
+    """The base class for all HTTP 404 errors raised by Synse Server.
+
+    All errors that will ultimately issue an HTTP 404 response to the
+    caller should either use this class or a subclass of this class.
+    Doing so will allow the response to have a JSON payload that
+    provides context for the error.
+
+    In general Synse Server 404 errors are returned when either the
+    request resource (e.g. a device) or some underlying resource
+    (e.g. a plugin) are not found.
+    """
+
+    def __init__(self, message, error_id=None):
+        NotFound.__init__(self, message)
+        SynseError.__init__(self, message, error_id)
+
+
+class SynseInvalidUsageError(InvalidUsage, SynseError):
+    """The base class for all HTTP 400 errors raised by Synse Server.
+
+    All errors that will ultimately issue an HTTP 400 response to the
+    caller should either use this class or a subclass of this class.
+    Doing so will allow the response to have a JSON payload that
+    provides context for the error.
+
+    In general Synse Server 400 errors are returned when information
+    given to a route is either invalid (e.g. bad JSON) or does not
+    conform to the API spec (e.g. required fields missing, query
+    param value format is invalid, etc.)
+    """
+
+    def __init__(self, message, error_id=None):
+        InvalidUsage.__init__(self, message)
+        SynseError.__init__(self, message, error_id)
+
+
+#
+# 400 - Invalid Usage
+#
+
+class InvalidArgumentsError(SynseInvalidUsageError):
     """Invalid or unexpected arguments provided."""
 
     def __init__(self, message):
         super(InvalidArgumentsError, self).__init__(message, INVALID_ARGUMENTS)
 
 
-class InvalidJsonError(SynseError):
+class InvalidJsonError(SynseInvalidUsageError):
     """Invalid JSON POSTed to endpoint."""
 
     def __init__(self, message):
         super(InvalidJsonError, self).__init__(message, INVALID_JSON)
 
 
-class InvalidDeviceType(SynseError):
+class InvalidDeviceType(SynseInvalidUsageError):
     """A device of some type is not handled by some route."""
 
     def __init__(self, message):
         super(InvalidDeviceType, self).__init__(message, INVALID_DEVICE_TYPE)
 
 
-class DeviceNotFoundError(SynseError):
+#
+# 404 - Not Found
+#
+
+class DeviceNotFoundError(SynseNotFoundError):
     """The specified device was not found."""
 
     def __init__(self, message):
         super(DeviceNotFoundError, self).__init__(message, DEVICE_NOT_FOUND)
 
 
-class BoardNotFoundError(SynseError):
+class BoardNotFoundError(SynseNotFoundError):
     """The specified board was not found."""
 
     def __init__(self, message):
         super(BoardNotFoundError, self).__init__(message, BOARD_NOT_FOUND)
 
 
-class RackNotFoundError(SynseError):
+class RackNotFoundError(SynseNotFoundError):
     """The specified rack was not found."""
 
     def __init__(self, message):
         super(RackNotFoundError, self).__init__(message, RACK_NOT_FOUND)
 
 
-class PluginNotFoundError(SynseError):
+class PluginNotFoundError(SynseNotFoundError):
     """The specified plugin was not found by Synse Server."""
 
     def __init__(self, message):
         super(PluginNotFoundError, self).__init__(message, PLUGIN_NOT_FOUND)
 
 
-class TransactionNotFoundError(SynseError):
+class TransactionNotFoundError(SynseNotFoundError):
     """The specified transaction was not found."""
 
     def __init__(self, message):
         super(TransactionNotFoundError, self).__init__(message, TRANSACTION_NOT_FOUND)
 
 
-class FailedInfoCommandError(SynseError):
+#
+# 500 - Internal Server Error
+#
+
+class FailedInfoCommandError(SynseServerError):
     """Error in executing an "info" command."""
 
     def __init__(self, message):
         super(FailedInfoCommandError, self).__init__(message, FAILED_INFO_COMMAND)
 
 
-class FailedReadCommandError(SynseError):
+class FailedReadCommandError(SynseServerError):
     """Error in executing a "read" command."""
 
     def __init__(self, message):
         super(FailedReadCommandError, self).__init__(message, FAILED_READ_COMMAND)
 
 
-class FailedWriteCommandError(SynseError):
+class FailedWriteCommandError(SynseServerError):
     """Error in executing a "write" command."""
 
     def __init__(self, message):
         super(FailedWriteCommandError, self).__init__(message, FAILED_WRITE_COMMAND)
 
 
-class FailedScanCommandError(SynseError):
+class FailedScanCommandError(SynseServerError):
     """Error in executing a "scan" command."""
 
     def __init__(self, message):
         super(FailedScanCommandError, self).__init__(message, FAILED_SCAN_COMMAND)
 
 
-class FailedTransactionCommandError(SynseError):
+class FailedTransactionCommandError(SynseServerError):
     """Error in executing a "transaction" command."""
 
     def __init__(self, message):
         super(FailedTransactionCommandError, self).__init__(message, FAILED_TRANSACTION_COMMAND)
 
 
-class InternalApiError(SynseError):
+class InternalApiError(SynseServerError):
     """General error for something that went wrong with the gRPC API."""
 
     def __init__(self, message):
         super(InternalApiError, self).__init__(message, INTERNAL_API_FAILURE)
 
 
-class PluginStateError(SynseError):
+class PluginStateError(SynseServerError):
     """Error for Synse Server plugin state being invalid or unexpected."""
 
     def __init__(self, message):

--- a/synse/scheme/read.py
+++ b/synse/scheme/read.py
@@ -113,8 +113,12 @@ class ReadResponse(SynseResponse):
             logger.debug(gettext('  Precision: {}').format(precision))
             value = reading.value
 
-            # Handle empty string.
-            if value == '':
+            # Handle cases where no data was read. Currently, we consider the reading
+            # to have no data if:
+            #   - the ReadResponse value comes back as an empty string (e.g. "")
+            #   - the ReadResponse value comes back as the string "null".
+            if value == '' or value == 'null':
+                logger.debug('reading value for {} came back as empty/null'.format(rt))
                 value = None
 
             else:

--- a/tests/integration/routes/aliases/test_boot_target_route.py
+++ b/tests/integration/routes/aliases/test_boot_target_route.py
@@ -11,7 +11,7 @@ invalid_boot_target_route_url = '/synse/{}/boot_target/invalid-rack/invalid-boar
 def test_boot_target_endpoint_invalid(app):
     """Get boot target info for a nonexistent device."""
     _, response = app.test_client.get(invalid_boot_target_route_url)
-    utils.test_error_json(response, errors.DEVICE_NOT_FOUND)
+    utils.test_error_json(response, errors.DEVICE_NOT_FOUND, 404)
 
 
 def test_boot_target_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/aliases/test_fan_route.py
+++ b/tests/integration/routes/aliases/test_fan_route.py
@@ -11,7 +11,7 @@ invalid_fan_route_url = '/synse/{}/fan/invalid-rack/invalid-board/invalid-device
 def test_fan_endpoint_invalid(app):
     """Get fan info for a nonexistent device."""
     _, response = app.test_client.get(invalid_fan_route_url)
-    utils.test_error_json(response, errors.DEVICE_NOT_FOUND)
+    utils.test_error_json(response, errors.DEVICE_NOT_FOUND, 404)
 
 
 def test_fan_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/aliases/test_led_route.py
+++ b/tests/integration/routes/aliases/test_led_route.py
@@ -11,7 +11,7 @@ invalid_led_route_url = '/synse/{}/led/invalid-rack/invalid-board/invalid-device
 def test_led_endpoint_invalid(app):
     """Get LED info for a nonexistent device."""
     _, response = app.test_client.get(invalid_led_route_url)
-    utils.test_error_json(response, errors.DEVICE_NOT_FOUND)
+    utils.test_error_json(response, errors.DEVICE_NOT_FOUND, 404)
 
 
 def test_led_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/aliases/test_power_route.py
+++ b/tests/integration/routes/aliases/test_power_route.py
@@ -11,7 +11,7 @@ invalid_power_route_url = '/synse/{}/power/invalid-rack/invalid-board/invalid-de
 def test_power_endpoint_invalid(app):
     """Get power info for a nonexistent device."""
     _, response = app.test_client.get(invalid_power_route_url)
-    utils.test_error_json(response, errors.DEVICE_NOT_FOUND)
+    utils.test_error_json(response, errors.DEVICE_NOT_FOUND, 404)
 
 
 def test_power_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/core/test_info_route.py
+++ b/tests/integration/routes/core/test_info_route.py
@@ -14,7 +14,7 @@ invalid_device_info_url = '{}/invalid-device'.format(invalid_board_info_url)
 def test_rack_info_endpoint_invalid(app):
     """Issue a request for a nonexistent rack."""
     _, response = app.test_client.get(invalid_rack_info_url)
-    utils.test_error_json(response, errors.RACK_NOT_FOUND)
+    utils.test_error_json(response, errors.RACK_NOT_FOUND, 404)
 
 
 def test_rack_info_endpoint_post_not_allowed(app):
@@ -60,7 +60,7 @@ def test_board_info_endpoint_invalid(app):
     error because of the lookup order.
     """
     _, response = app.test_client.get(invalid_board_info_url)
-    utils.test_error_json(response, errors.RACK_NOT_FOUND)
+    utils.test_error_json(response, errors.RACK_NOT_FOUND, 404)
 
 
 def test_board_info_endpoint_post_not_allowed(app):
@@ -106,7 +106,7 @@ def test_device_info_endpoint_invalid(app):
     error because of the lookup order.
     """
     _, response = app.test_client.get(invalid_device_info_url)
-    utils.test_error_json(response, errors.RACK_NOT_FOUND)
+    utils.test_error_json(response, errors.RACK_NOT_FOUND, 404)
 
 
 def test_device_info_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/core/test_read_route.py
+++ b/tests/integration/routes/core/test_read_route.py
@@ -16,7 +16,7 @@ def test_read_endpoint_invalid(app):
     one component is wrong, the ID composite device ID is wrong.
     """
     _, response = app.test_client.get(invalid_read_url)
-    utils.test_error_json(response, errors.DEVICE_NOT_FOUND)
+    utils.test_error_json(response, errors.DEVICE_NOT_FOUND, 404)
 
 
 def test_read_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/core/test_transaction_route.py
+++ b/tests/integration/routes/core/test_transaction_route.py
@@ -11,7 +11,7 @@ invalid_transaction_url = '/synse/{}/transaction/invalid-id'.format(__api_versio
 def test_transaction_endpoint_invalid(app):
     """Test getting a invalid transaction response."""
     _, response = app.test_client.get(invalid_transaction_url)
-    utils.test_error_json(response, errors.TRANSACTION_NOT_FOUND)
+    utils.test_error_json(response, errors.TRANSACTION_NOT_FOUND, 404)
 
 
 def test_transaction_endpoint_post_not_allowed(app):

--- a/tests/integration/routes/core/test_write_route.py
+++ b/tests/integration/routes/core/test_write_route.py
@@ -46,7 +46,7 @@ def test_write_invalid_endpoint_valid_data(app):
 
     for option, payload in valid_post_data.items():
         _, response = app.test_client.post(invalid_write_url, data=ujson.dumps(payload))
-        utils.test_error_json(response, errors.DEVICE_NOT_FOUND)
+        utils.test_error_json(response, errors.DEVICE_NOT_FOUND, 404)
 
 
 def test_write_invalid_endpoint_invalid_data(app):
@@ -66,7 +66,7 @@ def test_write_invalid_endpoint_invalid_data(app):
     
     for option, payload in invalid_post_data.items():
         _, response = app.test_client.post(invalid_write_url, data=ujson.dumps(payload))
-        utils.test_error_json(response, errors.INVALID_ARGUMENTS)
+        utils.test_error_json(response, errors.INVALID_ARGUMENTS, 400)
 
 
 def test_write_endpoint_post_not_allowed(app):

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -9,10 +9,12 @@ def test_synse_error_unknown():
     """Create a SynseError with no error id specified."""
     e = errors.SynseError('message')
 
-    assert isinstance(e, exceptions.ServerError)
+    assert not isinstance(e, exceptions.ServerError)
+    assert not isinstance(e, exceptions.InvalidUsage)
+    assert not isinstance(e, exceptions.NotFound)
     assert isinstance(e, errors.SynseError)
 
-    assert e.status_code == 500
+    assert not hasattr(e, 'status_code')
     assert e.error_id == errors.UNKNOWN
     assert e.args[0] == 'message'
 
@@ -21,10 +23,11 @@ def test_synse_error_device_not_found():
     """Check for DEVICE_NOT_FOUND error"""
     e = errors.DeviceNotFoundError('message')
 
-    assert isinstance(e, exceptions.ServerError)
+    assert isinstance(e, exceptions.NotFound)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseNotFoundError)
 
-    assert e.status_code == 500
+    assert e.status_code == 404
     assert e.error_id == errors.DEVICE_NOT_FOUND
     assert e.args[0] == 'message'
 
@@ -33,10 +36,11 @@ def test_synse_error_board_not_found():
     """Check for BOARD_NOT_FOUND error"""
     e = errors.BoardNotFoundError('message')
 
-    assert isinstance(e, exceptions.ServerError)
+    assert isinstance(e, exceptions.NotFound)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseNotFoundError)
 
-    assert e.status_code == 500
+    assert e.status_code == 404
     assert e.error_id == errors.BOARD_NOT_FOUND
     assert e.args[0] == 'message'
 
@@ -45,10 +49,11 @@ def test_synse_error_rack_not_found():
     """Check for RACK_NOT_FOUND error"""
     e = errors.RackNotFoundError('message')
 
-    assert isinstance(e, exceptions.ServerError)
+    assert isinstance(e, exceptions.NotFound)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseNotFoundError)
 
-    assert e.status_code == 500
+    assert e.status_code == 404
     assert e.error_id == errors.RACK_NOT_FOUND
     assert e.args[0] == 'message'
 
@@ -57,10 +62,11 @@ def test_synse_error_plugin_not_found():
     """Check for PLUGIN_NOT_FOUND error"""
     e = errors.PluginNotFoundError('message')
 
-    assert isinstance(e, exceptions.ServerError)
+    assert isinstance(e, exceptions.NotFound)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseNotFoundError)
 
-    assert e.status_code == 500
+    assert e.status_code == 404
     assert e.error_id == errors.PLUGIN_NOT_FOUND
     assert e.args[0] == 'message'
 
@@ -69,10 +75,11 @@ def test_synse_error_transaction_not_found():
     """Check for TRANSACTION_NOT_FOUND error"""
     e = errors.TransactionNotFoundError('message')
 
-    assert isinstance(e, exceptions.ServerError)
+    assert isinstance(e, exceptions.NotFound)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseNotFoundError)
 
-    assert e.status_code == 500
+    assert e.status_code == 404
     assert e.error_id == errors.TRANSACTION_NOT_FOUND
     assert e.args[0] == 'message'
 
@@ -83,6 +90,7 @@ def test_synse_error_failed_info_command():
 
     assert isinstance(e, exceptions.ServerError)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseServerError)
 
     assert e.status_code == 500
     assert e.error_id == errors.FAILED_INFO_COMMAND
@@ -95,6 +103,7 @@ def test_synse_error_failed_read_command():
 
     assert isinstance(e, exceptions.ServerError)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseServerError)
 
     assert e.status_code == 500
     assert e.error_id == errors.FAILED_READ_COMMAND
@@ -107,6 +116,7 @@ def test_synse_error_failed_scan_command():
 
     assert isinstance(e, exceptions.ServerError)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseServerError)
 
     assert e.status_code == 500
     assert e.error_id == errors.FAILED_SCAN_COMMAND
@@ -119,6 +129,7 @@ def test_synse_error_failed_transaction_command():
 
     assert isinstance(e, exceptions.ServerError)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseServerError)
 
     assert e.status_code == 500
     assert e.error_id == errors.FAILED_TRANSACTION_COMMAND
@@ -131,6 +142,7 @@ def test_synse_error_failed_write_command():
 
     assert isinstance(e, exceptions.ServerError)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseServerError)
 
     assert e.status_code == 500
     assert e.error_id == errors.FAILED_WRITE_COMMAND
@@ -143,6 +155,7 @@ def test_synse_error_internal_api():
 
     assert isinstance(e, exceptions.ServerError)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseServerError)
 
     assert e.status_code == 500
     assert e.error_id == errors.INTERNAL_API_FAILURE
@@ -155,6 +168,7 @@ def test_synse_error_plugin_state():
 
     assert isinstance(e, exceptions.ServerError)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseServerError)
 
     assert e.status_code == 500
     assert e.error_id == errors.PLUGIN_STATE_ERROR
@@ -163,12 +177,13 @@ def test_synse_error_plugin_state():
 
 def test_synse_error_request_url_not_found():
     """Check for URL_NOT_FOUND error"""
-    e = errors.SynseError('message', errors.URL_NOT_FOUND)
+    e = errors.SynseNotFoundError('message', errors.URL_NOT_FOUND)
 
-    assert isinstance(e, exceptions.ServerError)
+    assert isinstance(e, exceptions.NotFound)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseNotFoundError)
 
-    assert e.status_code == 500
+    assert e.status_code == 404
     assert e.error_id == errors.URL_NOT_FOUND
     assert e.args[0] == 'message'
 
@@ -177,10 +192,11 @@ def test_synse_error_request_invalid_arguments():
     """Check for INVALID_ARGUMENTS error"""
     e = errors.InvalidArgumentsError('message')
 
-    assert isinstance(e, exceptions.ServerError)
+    assert isinstance(e, exceptions.InvalidUsage)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseInvalidUsageError)
 
-    assert e.status_code == 500
+    assert e.status_code == 400
     assert e.error_id == errors.INVALID_ARGUMENTS
     assert e.args[0] == 'message'
 
@@ -189,10 +205,11 @@ def test_synse_error_request_invalid_json():
     """Check for INVALID_JSON error"""
     e = errors.InvalidJsonError('message')
 
-    assert isinstance(e, exceptions.ServerError)
+    assert isinstance(e, exceptions.InvalidUsage)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseInvalidUsageError)
 
-    assert e.status_code == 500
+    assert e.status_code == 400
     assert e.error_id == errors.INVALID_JSON
     assert e.args[0] == 'message'
 
@@ -201,9 +218,10 @@ def test_synse_error_request_invalid_device_type():
     """Check for INVALID_DEVICE_TYPE error"""
     e = errors.InvalidDeviceType('message')
 
-    assert isinstance(e, exceptions.ServerError)
+    assert isinstance(e, exceptions.InvalidUsage)
     assert isinstance(e, errors.SynseError)
+    assert isinstance(e, errors.SynseInvalidUsageError)
 
-    assert e.status_code == 500
+    assert e.status_code == 400
     assert e.error_id == errors.INVALID_DEVICE_TYPE
     assert e.args[0] == 'message'


### PR DESCRIPTION
**Review Deadline**: --

## Summary
this PR does two things:
- makes some more distinction between error response code (400, 404, 500) based on the type of error. before everything was just a 500 with some context message. we still have the same context message, but can use the HTTP codes to differentiate.
- unifies the response of Synse Server for "no data" responses. There is a large comment in the code that talks about the different responses. Now, anything that has no data will have the `null` type as the value, e.g.
```json
{
  "type":"temperature",
  "data":{
    "temperature":{
      "value":null,
      "timestamp":"2018-03-13T19:39:25.714344+00:00",
      "unit":{
        "symbol":"C",
        "name":"degrees celsius"
      }
    }
  }
}
```


## Related Issues
- fixes #88
