### PR TITLE
add unix plugins in default dir to the config for visibility

### DIFF
--- a/synse/plugin.py
+++ b/synse/plugin.py
@@ -264,6 +264,15 @@ def register_unix_plugins():
                     # a new plugin gets added to the manager on initialization.
                     plugin = Plugin(name=name, address=fqn, mode='unix')
                     logger.debug(gettext('Created new plugin (unix): {}').format(plugin))
+
+                    # add the plugin to the Synse Server configuration. this will
+                    # allow a caller of the '/config' endpoint to see what plugins
+                    # are configured. further, it can help with other processing that
+                    # might need the list of configured plugins.
+                    #
+                    # The value of `None` is used to indicate the default directory.
+                    config.options.set('plugin.unix.{}'.format(name), None)
+
                 else:
                     logger.info(
                         gettext('plugin "{}" already exists - will not re-register (unix)')

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -186,7 +186,14 @@ def test_register_plugins_ok():
 
     assert len(plugin.Plugin.manager.plugins) == 0
 
+    # the plugin is not yet in the config
+    assert config.options.get('plugin.unix') is None
+
     plugin.register_plugins()
+
+    # the plugin has been added to the config (because it was
+    # in the default socket directory)
+    assert 'test' in config.options.get('plugin.unix')
 
     assert len(plugin.Plugin.manager.plugins) == 1
     assert 'test' in plugin.Plugin.manager.plugins


### PR DESCRIPTION
**Review Deadline**: --

## Summary
for visibility, updates the config with plugins that are configured from the default unix socket directory.

## Related Issues
- fixes #89 