### PR TITLE
fix ENV variable for setting logging levels in makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ endif
 
 .PHONY: run
 run: docker ## Build and run Synse Server locally (localhost:5000) with emulator
-	docker run -d -p 5000:5000 --name synse -e SYNSE_DEBUG=true ${IMG_NAME} enable-emulator
+	docker run -d -p 5000:5000 --name synse -e SYNSE_LOGGING=debug ${IMG_NAME} enable-emulator
 
 .PHONY: test
 test: pycache-clean test-unit test-integration test-end-to-end ## Run all tests


### PR DESCRIPTION
**Review Deadline**: --

## Summary
`SYNSE_DEBUG` is not the env variable we use anymore to set logging. This changed a while ago, but it seems like this slipped through the cracks and wasn't updated. 

To set logging levels for Synse Server, we now use `SYNSE_LOGGING`, where the valid values for it are `"debug"`, `"info"`, `"warning"`, or `"error"` (default level is info)