### PR TITLE
add location info to fan sensors readings

### DIFF
--- a/synse/commands/fan_sensors.py
+++ b/synse/commands/fan_sensors.py
@@ -52,7 +52,11 @@ async def fan_sensors():
                 logger.debug('fan_sensors data: {}.'.format(single_reading))
                 # Wedge in the VEC name that we received this data from.
                 # That way auto_fan can map the data to a VEC.
-                single_reading['vec'] = rack
+                single_reading['location'] = {
+                    'rack': rack,
+                    'board': board,
+                    'device': device
+                }
                 logger.debug('fan_sensors data with vec: {}.'.format(single_reading))
                 readings.append(single_reading)
 


### PR DESCRIPTION
**Review Deadline**: --

## Summary
- adds full locational info as part of the read response for a device. with this every reading is tied to its originating rack/board/device id