### PR TITLE
Pressure rename

### DIFF
--- a/emulator/config/device/pressure.yaml
+++ b/emulator/config/device/pressure.yaml
@@ -4,7 +4,7 @@ locations:
     rack: rack-1
     board: vec
 devices:
-  - type: differential_pressure
+  - type: pressure
     model: emul8-pressure
     instances:
       - id: "1"

--- a/emulator/config/proto/pressure.yaml
+++ b/emulator/config/proto/pressure.yaml
@@ -1,6 +1,6 @@
 version: 1.0
 prototypes:
-  - type: differential_pressure
+  - type: pressure
     model: emul8-pressure
     manufacturer: Vapor IO
     protocol: emulator

--- a/synse/commands/fan_sensors.py
+++ b/synse/commands/fan_sensors.py
@@ -35,7 +35,7 @@ async def fan_sensors():
         logger.info('fan_sensors cache item: {}'.format(v))
 
         is_temp = v.type.lower() == 'temperature' and v.model.lower() == 'max11610'
-        is_pressure = v.type.lower() == 'differential_pressure' and v.model.lower() == 'sdp610'
+        is_pressure = v.type.lower() == 'pressure' and v.model.lower() == 'sdp610'
 
         if is_temp or is_pressure:
             rack = v.location.rack


### PR DESCRIPTION
**Review Deadline**: --

## Summary
Renames the "differential_pressure" device to just "pressure" to make things more general, simple, and consistent. This is relating to the work done for the emulator: https://github.com/vapor-ware/synse-emulator-plugin/pull/12