### PR TITLE
Revert "change fan route params to 'rpm' and 'percent'"

### DIFF
--- a/synse/routes/aliases.py
+++ b/synse/routes/aliases.py
@@ -112,50 +112,24 @@ async def fan_route(request, rack, board, device):
     """
     await validate.validate_device_type(const.TYPE_FAN, rack, board, device)
 
-    param_percent = request.raw_args.get('percent')
-    param_rpm = request.raw_args.get('rpm')
+    param_speed = request.raw_args.get('speed')
 
-    # if any of the parameters are specified, then this will be a
-    # write request for those parameters that are specified.
-    if any((param_percent, param_rpm)):
-        data = []
+    # if a request parameter is specified, this will translate to a
+    # write request.
+    if param_speed is not None:
+        # FIXME - is the below true? could we check against the device prototype's
+        #   "range.min" and "range.max" fields for this?
+        # no validation is done on the fan speed. valid fan speeds vary based on
+        # fan make/model, so it is up to the underlying implementation to do the
+        # validation.
+        data = {
+            'action': 'speed',
+            'raw': param_speed
+        }
+        transaction = await commands.write(rack, board, device, data)
+        return transaction.to_json()
 
-        if param_rpm:
-            # FIXME - could we check against the device prototype's
-            #   "range.min" and "range.max" fields for this?
-            # no validation is done on the fan speed. valid fan speeds vary based on
-            # fan make/model, so it is up to the underlying implementation to do the
-            # validation.
-            data.append({
-                'action': 'rpm',
-                'raw': param_rpm
-            })
-
-        if param_percent:
-            try:
-                assert 0 <= int(param_percent) <= 100
-            except Exception as e:
-                raise errors.InvalidArgumentsError(
-                    gettext('Invalid percentage value ({}). Must be a value '
-                            'between 0 and 100.').format(param_percent)
-                ) from e
-
-            data.append({
-                'action': 'percent',
-                'raw': param_percent
-            })
-
-        transactions = None
-        for d in data:
-            t = await commands.write(rack, board, device, d)
-            if not transactions:
-                transactions = t
-            else:
-                transactions.data.extend(t.data)
-
-        return transactions.to_json()
-
-    # if no request parameters are specified, this will translate to a
+    # if no request parameter is specified, this will translate to a
     # read request.
     else:
         reading = await commands.read(rack, board, device)

--- a/tests/unit/routes/aliases/test_fan_route.py
+++ b/tests/unit/routes/aliases/test_fan_route.py
@@ -74,62 +74,23 @@ async def test_synse_fan_read(mock_validate_device_type, mock_read, no_pretty_js
 async def test_synse_fan_write_invalid(mock_validate_device_type, mock_write, no_pretty_json):
     """Test writing fan speed with an invalid speed specified."""
 
-    r = utils.make_request('/synse/fan?rpm=test')
+    r = utils.make_request('/synse/fan?speed=test')
 
     try:
         await fan_route(r, 'rack-1', 'vec', '123456')
     except errors.SynseError as e:
         assert e.error_id == errors.INVALID_ARGUMENTS
         assert 'test' in e.args[0]
-
-
-@pytest.mark.asyncio
-async def test_synse_fan_write_invalid2(mock_validate_device_type, mock_write, no_pretty_json):
-    """Test writing fan speed with an invalid speed specified."""
-
-    r = utils.make_request('/synse/fan?percent=test')
-
-    try:
-        await fan_route(r, 'rack-1', 'vec', '123456')
-    except errors.SynseError as e:
-        assert e.error_id == errors.INVALID_ARGUMENTS
-        assert 'test' in e.args[0]
-
-
-@pytest.mark.asyncio
-async def test_synse_fan_write_invalid3(mock_validate_device_type, mock_write, no_pretty_json):
-    """Test writing fan speed with an invalid speed specified."""
-
-    r = utils.make_request('/synse/fan?percent=1000')
-
-    try:
-        await fan_route(r, 'rack-1', 'vec', '123456')
-    except errors.SynseError as e:
-        assert e.error_id == errors.INVALID_ARGUMENTS
-        assert 'invalid percentage' in e.args[0].lower()
 
 
 @pytest.mark.asyncio
 async def test_synse_fan_write_valid(mock_validate_device_type, mock_write, no_pretty_json):
     """Test writing fan speed with a valid target specified."""
 
-    r = utils.make_request('/synse/fan?rpm=500')
+    r = utils.make_request('/synse/fan?speed=500')
 
     result = await fan_route(r, 'rack-1', 'vec', '123456')
 
     assert isinstance(result, HTTPResponse)
-    assert result.body == b'{"data":{"action":"rpm","raw":"500"}}'
-    assert result.status == 200
-
-
-@pytest.mark.asyncio
-async def test_synse_fan_write_valid2(mock_validate_device_type, mock_write, no_pretty_json):
-    """Test writing fan speed with a valid target specified."""
-
-    r = utils.make_request('/synse/fan?percent=50')
-
-    result = await fan_route(r, 'rack-1', 'vec', '123456')
-
-    assert isinstance(result, HTTPResponse)
-    assert result.body == b'{"data":{"action":"percent","raw":"50"}}'
+    assert result.body == b'{"data":{"action":"speed","raw":"500"}}'
     assert result.status == 200


### PR DESCRIPTION
Reverting this commit makes the fan work on real hardware again.

See https://github.com/vapor-ware/synse-plugins-internal/pull/132