### PR TITLE
make all timestamps rfc3339 formatted

### DIFF
--- a/synse/commands/read.py
+++ b/synse/commands/read.py
@@ -2,12 +2,10 @@
 """
 # pylint: disable=line-too-long
 
-from datetime import datetime, timezone
-
 import grpc
 from synse_plugin import api
 
-from synse import cache, errors, plugin
+from synse import cache, errors, plugin, utils
 from synse.i18n import gettext
 from synse.log import logger
 from synse.scheme import ReadResponse
@@ -36,6 +34,7 @@ async def read(rack, board, device):
             gettext('Unable to find plugin named "{}" to read.').format(plugin_name)
         )
 
+    read_data = []
     try:
         # perform a gRPC read on the device's managing plugin
         read_data = _plugin.client.read(rack, board, device)
@@ -83,11 +82,10 @@ async def read(rack, board, device):
                     'apply None as reading value. Note that this response might '
                     'indicate plugin error/misconfiguration.'.format(rack, board, device))
                 read_data = []
-                local_time = datetime.now(timezone.utc).astimezone()
                 for output in dev.output:
                     read_data.append(
                         api.ReadResponse(
-                            timestamp=local_time.isoformat(),
+                            timestamp=utils.rfc3339now(),
                             type=output.type,
                             value='',
                         )

--- a/synse/factory.py
+++ b/synse/factory.py
@@ -1,13 +1,11 @@
 """Factory for creating Synse Server Sanic application instances."""
 # pylint: disable=unused-variable,unused-argument
 
-import datetime
-
 from sanic import Sanic
 from sanic.exceptions import InvalidUsage, NotFound, ServerError
 from sanic.response import text
 
-from synse import config, errors
+from synse import config, errors, utils
 from synse.cache import configure_cache
 from synse.i18n import init_gettext
 from synse.log import LOGGING, logger, setup_logger
@@ -107,7 +105,7 @@ def _make_error(error_id, exception):
         'http_code': exception.status_code,
         'error_id': error_id,
         'description': errors.codes[error_id],
-        'timestamp': str(datetime.datetime.utcnow()),
+        'timestamp': utils.rfc3339now(),
         'context': str(exception)
 
     }

--- a/synse/scheme/test.py
+++ b/synse/scheme/test.py
@@ -1,8 +1,7 @@
 """Response scheme for the `test` endpoint.
 """
 
-import datetime
-
+from synse import utils
 from synse.scheme.base_response import SynseResponse
 
 
@@ -41,4 +40,4 @@ class TestResponse(SynseResponse):
 
     def __init__(self):
         """Constructor for the TestResponse class."""
-        self.data['timestamp'] = str(datetime.datetime.utcnow())
+        self.data['timestamp'] = utils.rfc3339now()

--- a/synse/utils.py
+++ b/synse/utils.py
@@ -1,6 +1,22 @@
 """Synse Server utility and convenience methods.
 """
 
+import datetime
+
+
+def rfc3339now():
+    """Create an RFC3339 formatted timestamp for the current
+    UTC time.
+
+    See Also:
+        https://stackoverflow.com/a/8556555
+
+    Returns:
+        str: The RFC3339 formatted timestamp.
+    """
+    now = datetime.datetime.utcnow()
+    return now.isoformat('T') + 'Z'
+
 
 def composite(rack, board, device):
     """Create a composite string out of a rack, board, and device.


### PR DESCRIPTION
**Review Deadline**: --

## Summary
makes all the synse server generated timestamps utc rfc3339 formatted, just as they are coming from plugins.

```
➜ curl localhost:5000/synse/test
{
  "status":"ok",
  "timestamp":"2018-03-25T14:07:41.814246Z"
}
➜ curl localhost:5000/synse/2.0/read/rack-1/vec/329a91c6781ce92370a3c38ba9bf35b2
{
  "type":"temperature",
  "data":{
    "temperature":{
      "value":5.0,
      "timestamp":"2018-03-25T14:07:53.8927973Z",
      "unit":{
        "symbol":"C",
        "name":"degrees celsius"
      }
    }
  }
}
```

## Related Issues
- fixes #103
