### PR TITLE
fix bug with socket lookup

### DIFF
--- a/synse/plugin.py
+++ b/synse/plugin.py
@@ -214,7 +214,7 @@ def register_unix_plugins():
                 path = const.SOCKET_DIR
 
             # Check for both 'plugin_name' and 'plugin_name.sock'
-            sock_path = os.path.join(path, name, '.sock')
+            sock_path = os.path.join(path, name + '.sock')
             logger.debug('checking for socket: {}'.format(sock_path))
             if not os.path.exists(sock_path):
                 logger.debug('checking for socket: {}'.format(sock_path))


### PR DESCRIPTION
**Review Deadline**: --

## Summary
I fixed this bug before, so I'm not sure why its back.. either way, we don't want to `os.path.join` the file extension, we want to append it to the end of the file name.