### PR TITLE
update deps so tests pass

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps=
     pytest-asyncio
     requests
     isort>=4.2.5
-    pytest>=3.1.0
+    pytest>=3.1.0,<3.5.0
     pytest-cov>=2.5.1
     pytest-html>=1.14.2
     pytest-mock>=1.6.0


### PR DESCRIPTION
**Review Deadline**: --

## Summary
the new version of pytest (3.5.0) breaks tests for some reason. this updates deps so we don't use 3.5.0

## Related Issues
- fixes #112 
