### PR TITLE
update synse server led api to make blink an led power state

### DIFF
--- a/docs/build/src/index.html.md
+++ b/docs/build/src/index.html.md
@@ -433,11 +433,6 @@ response = requests.get('http://host:5000/synse/2.0/read/rack-1/vec/eb100067acb0
       "value": "000000",
       "timestamp": "2018-02-01T13:48:59.573898829Z",
       "unit": null
-    },
-    "blink": {
-      "value": "steady",
-      "timestamp": "2018-02-01T13:48:59.573898829Z",
-      "unit": null
     }
   }
 }
@@ -570,7 +565,7 @@ The post body requires an "action" and "raw" to be specified, e.g.
 | *raw* | The data associated with the given action. |
 
 The valid values and requirements for `action` and `raw` are dependent on the device type/plugin
-implementation. For example, an `LED` device supports the actions: `color`, `state`, `blink`; a
+implementation. For example, an `LED` device supports the actions: `color`, `state`; a
 `fan` device supports `speed`. 
 
 Some devices may only need an `action` specified. Some may need both `action` and `raw` specified.
@@ -850,11 +845,6 @@ response = requests.get('http://host:5000/synse/2.0/led/rack-1/vec/f52d29fecf05a
       "value": "f38ac2",
       "timestamp": "2018-02-01T16:16:04.884816422Z",
       "unit": null
-    },
-    "blink": {
-      "value": "steady",
-      "timestamp": "2018-02-01T16:16:04.884816422Z",
-      "unit": null
     }
   }
 }
@@ -924,8 +914,7 @@ of valid query parameters are specified, the endpoint will write to the specifie
 
 | Parameter | Description |
 | --------- | ----------- |
-| *state*   | The state of the LED. *Valid values:* (`on`, `off`) |
-| *blink*   | The blink state of the LED. *Valid values:* (`blink`, `steady`) |
+| *state*   | The state of the LED. *Valid values:* (`on`, `off`, `blink`) |
 | *color*   | The color of the LED. This must be an RGB hexadecimal color string. |
 
 <aside class="warning">

--- a/emulator/config/proto/led.yaml
+++ b/emulator/config/proto/led.yaml
@@ -9,5 +9,3 @@ prototypes:
         data_type: string
       - type: color
         data_type: string
-      - type: blink
-        data_type: string

--- a/synse/const.py
+++ b/synse/const.py
@@ -16,18 +16,12 @@ TYPE_LOCK = 'lock'
 LED_ON = 'on'
 LED_OFF = 'off'
 LED_BLINK = 'blink'
-LED_STEADY = 'steady'
 
 # all LED states
 led_states = (
     LED_ON,
-    LED_OFF
-)
-
-# all LED blink states
-led_blink_states = (
-    LED_BLINK,
-    LED_STEADY
+    LED_OFF,
+    LED_BLINK
 )
 
 

--- a/synse/routes/aliases.py
+++ b/synse/routes/aliases.py
@@ -15,7 +15,7 @@ bp = Blueprint(__name__, url_prefix='/synse/' + __api_version__)
 async def led_route(request, rack, board, device):
     """Endpoint to read/write LED device data.
 
-    If no state, color, or blink is specified through request parameters,
+    If no state or color is specified through request parameters,
     this will translate to a device read. Otherwise, if any valid request
     parameter is specified, this will translate to a device write.
 
@@ -31,12 +31,11 @@ async def led_route(request, rack, board, device):
     await validate.validate_device_type(const.TYPE_LED, rack, board, device)
 
     param_state = request.raw_args.get('state')
-    param_blink = request.raw_args.get('blink')
     param_color = request.raw_args.get('color')
 
     # if any of the parameters are specified, then this will be
     # a write request for those parameters that are specified.
-    if any((param_state, param_blink, param_color)):
+    if any((param_state, param_color)):
         data = []
 
         if param_state:
@@ -49,18 +48,6 @@ async def led_route(request, rack, board, device):
             data.append({
                 'action': 'state',
                 'raw': param_state
-            })
-
-        if param_blink:
-            if param_blink not in const.led_blink_states:
-                raise errors.InvalidArgumentsError(
-                    gettext('Invalid blink state "{}". Must be one of: {}').format(
-                        param_blink, const.led_blink_states)
-                )
-
-            data.append({
-                'action': 'blink',
-                'raw': param_blink
             })
 
         if param_color:

--- a/synse/scheme/transaction.py
+++ b/synse/scheme/transaction.py
@@ -19,8 +19,8 @@ class TransactionResponse(SynseResponse):
         {
           "id": "b7jl0b2un4a154rn9u4g",
           "context": {
-            "action": "blink",
-            "raw": ["steady"]
+            "action": "state",
+            "raw": ["on"]
           },
           "state": "ok",
           "status": "pending",

--- a/synse/scheme/write.py
+++ b/synse/scheme/write.py
@@ -17,8 +17,8 @@ class WriteResponse(SynseResponse):
         [
           {
             "context": {
-              "action": "blink",
-              "raw": ["steady"]
+              "action": "state",
+              "raw": ["on"]
             },
             "timestamp": "2017-11-08 14:01:53",
             "transaction": "b7jl0b2un4a154rn9u4g"

--- a/tests/unit/routes/aliases/test_led_route.py
+++ b/tests/unit/routes/aliases/test_led_route.py
@@ -94,7 +94,7 @@ async def test_synse_led_write_invalid_1(mock_validate_device_type, mock_write, 
 async def test_synse_led_write_invalid_2(mock_validate_device_type, mock_write, no_pretty_json):
     """Test writing LED state with an invalid state specified."""
 
-    r = utils.make_request('/synse/led?blink=foo')
+    r = utils.make_request('/synse/led?state=foo')
 
     try:
         await led_route(r, 'rack-1', 'vec', '123456')
@@ -120,7 +120,7 @@ async def test_synse_led_write_invalid_3(mock_validate_device_type, mock_write, 
 async def test_synse_led_write_invalid_4(mock_validate_device_type, mock_write, no_pretty_json):
     """Test writing LED state with an invalid state specified."""
 
-    r = utils.make_request('/synse/led?state=on&color=ff0044&blink=bar')
+    r = utils.make_request('/synse/led?state=on&color=bar')
 
     try:
         await led_route(r, 'rack-1', 'vec', '123456')
@@ -185,25 +185,12 @@ async def test_synse_led_write_valid_2(mock_validate_device_type, mock_write, no
 async def test_synse_led_write_valid_3(mock_validate_device_type, mock_write, no_pretty_json):
     """Test writing LED state with a valid state specified."""
 
-    r = utils.make_request('/synse/led?blink=blink')
+    r = utils.make_request('/synse/led?state=blink')
 
     result = await led_route(r, 'rack-1', 'vec', '123456')
 
     assert isinstance(result, HTTPResponse)
-    assert result.body == b'[{"context":{"action":"blink","raw":["blink"]},"transaction":"rack-1-vec-123456"}]'
-    assert result.status == 200
-
-
-@pytest.mark.asyncio
-async def test_synse_led_write_valid_4(mock_validate_device_type, mock_write, no_pretty_json):
-    """Test writing LED state with a valid state specified."""
-
-    r = utils.make_request('/synse/led?blink=steady')
-
-    result = await led_route(r, 'rack-1', 'vec', '123456')
-
-    assert isinstance(result, HTTPResponse)
-    assert result.body == b'[{"context":{"action":"blink","raw":["steady"]},"transaction":"rack-1-vec-123456"}]'
+    assert result.body == b'[{"context":{"action":"state","raw":["blink"]},"transaction":"rack-1-vec-123456"}]'
     assert result.status == 200
 
 
@@ -224,13 +211,12 @@ async def test_synse_led_write_valid_5(mock_validate_device_type, mock_write, no
 async def test_synse_led_write_valid_6(mock_validate_device_type, mock_write, no_pretty_json):
     """Test writing LED state with a valid state specified."""
 
-    r = utils.make_request('/synse/led?color=ffffff&state=on&blink=steady')
+    r = utils.make_request('/synse/led?color=ffffff&state=on')
 
     result = await led_route(r, 'rack-1', 'vec', '123456')
 
     expected = [
         {'context': {'action': 'state', 'raw': [b'on']}, 'transaction': 'rack-1-vec-123456'},
-        {'context': {'action': 'blink', 'raw': [b'steady']}, 'transaction': 'rack-1-vec-123456'},
         {'context': {'action': 'color', 'raw': [b'ffffff']}, 'transaction': 'rack-1-vec-123456'}
     ]
 


### PR DESCRIPTION
**Review Deadline**: -- 

## Summary
Changes to the LED API to remove "blink" as an LED action and instead make it a value for LED power state. This PR also updates corresponding tests and documentation, and updates the emulator to use the latest version of it which also implements these changes to the emulated LED device.