### PR TITLE
Update fan_sensors route for auto fan.

### DIFF
--- a/synse/cache.py
+++ b/synse/cache.py
@@ -480,6 +480,9 @@ def _build_scan_cache(metainfo):
             ref['rack']['boards'] = list(ref['boards'].values())
             scan_cache['racks'].append(ref['rack'])
 
+        # Sort the scan cache by racks['id']
+        scan_cache['racks'] = sorted(scan_cache['racks'], key=lambda rck: rck['id'])
+
     return scan_cache
 
 

--- a/synse/commands/fan_sensors.py
+++ b/synse/commands/fan_sensors.py
@@ -1,9 +1,57 @@
 """Command handler for the `fan sensor` route.
 """
 
+import datetime
+from collections import OrderedDict
+
 from synse import cache
 from synse.commands.read import read
 from synse.log import logger
+
+
+# TODO: Need a note in the configuration files about auto_fan relying on
+# device information names in order to find these sensors.
+def _translate_device_info(device_info):
+    """
+    This translates the device info of the scan device to the field output in a
+    fan sensors result set.
+    :param device_info: The info field of the device in a scan.
+    :return: The field output in a fan sensors result set.
+    """
+    if device_info.startswith('Rack Temperature 0 '):
+        return 'thermistor_0'
+    if device_info.startswith('Rack Temperature 1 '):
+        return 'thermistor_1'
+    if device_info.startswith('Rack Temperature 2 '):
+        return 'thermistor_2'
+    if device_info.startswith('Rack Temperature 3 '):
+        return 'thermistor_3'
+    if device_info.startswith('Rack Temperature 4 '):
+        return 'thermistor_4'
+    if device_info.startswith('Rack Temperature 5 '):
+        return 'thermistor_5'
+    if device_info.startswith('Rack Temperature 6 '):
+        return 'thermistor_6'
+    if device_info.startswith('Rack Temperature 7 '):
+        return 'thermistor_7'
+    if device_info.startswith('Rack Temperature 8 '):
+        return 'thermistor_8'
+    if device_info.startswith('Rack Temperature 9 '):
+        return 'thermistor_9'
+    if device_info.startswith('Rack Temperature 10 '):
+        return 'thermistor_10'
+    if device_info.startswith('Rack Temperature 11 '):
+        return 'thermistor_11'
+
+    if device_info == 'Rack Differential Pressure Bottom':
+        return 'differential_pressure_0'
+    if device_info == 'Rack Differential Pressure Middle':
+        return 'differential_pressure_1'
+    if device_info == 'Rack Differential Pressure Top':
+        return 'differential_pressure_2'
+
+    logger.error('Unknown device_info: {}'.format(device_info))
+    return None
 
 
 async def fan_sensors():
@@ -24,23 +72,42 @@ async def fan_sensors():
     #
     # to read all the devices of a given type or model.
 
+    start_time = datetime.datetime.now()
     _cache = await cache.get_metainfo_cache()
+    scan_cache = await cache.get_scan_cache()
 
     readings = []
+    new_readings = dict()
+    new_readings['racks'] = OrderedDict()
 
     logger.debug('--- FAN SENSORS start ---')
     for _, v in _cache.items():
 
         logger.debug('FAN SENSORS')
-        logger.info('fan_sensors cache item: {}'.format(v))
+        logger.debug('fan_sensors cache item: {}'.format(v))
 
         is_temp = v.type.lower() == 'temperature' and v.model.lower() == 'max11610'
         is_pressure = v.type.lower() == 'pressure' and v.model.lower() == 'sdp610'
 
         if is_temp or is_pressure:
-            rack = v.location.rack
-            board = v.location.board
-            device = v.uid
+            rack = v.location.rack # string (vec1-c1-wrigley for example)
+            board = v.location.board # string (vec for example)
+            device = v.uid # string (uuid - only unique to one rack)
+
+            # Find the device in the scan_cache.
+            scan_cache_board = None
+            scan_cache_device = None
+            scan_cache_rack = next((r for r in scan_cache['racks'] if r['id'] == rack), None)
+            if scan_cache_rack is not None:
+                scan_cache_board = next(
+                    (b for b in scan_cache_rack['boards'] if b['id'] == board), None)
+                if scan_cache_board is not None:
+                    scan_cache_device = next(
+                        (d for d in scan_cache_board['devices'] if d['id'] == device), None)
+            logger.debug('scan_cache_rack_id, board_id, device_info: {}, {}, {}'.format(
+                scan_cache_rack.get('id', None),
+                scan_cache_board.get('id', None),
+                scan_cache_device.get('info', None)))
 
             try:
                 resp = await read(rack, board, device)
@@ -55,10 +122,56 @@ async def fan_sensors():
                 single_reading['location'] = {
                     'rack': rack,
                     'board': board,
-                    'device': device
+                    'device': device,
                 }
+                single_reading['scan_cache_device'] = scan_cache_device
                 logger.debug('fan_sensors data with vec: {}.'.format(single_reading))
                 readings.append(single_reading)
 
+                # If the rack is not a key in new readings, add it.
+                if rack not in new_readings['racks']:
+                    new_readings['racks'][rack] = dict()
+
+                # Translate single_reading['scan_cache_device']['info']
+                # and add it under the rack key which is:
+                # new_readings['racks'][rack][translation] \
+                #     = single_reading['data'][single_reading['type']]['value']
+                logger.debug(
+                    'single_reading[scan_cache_device][info]: {}'.format(
+                        single_reading['scan_cache_device']['info']))
+                logger.debug(
+                    'single_reading[data][single_reading[type]][value]: {}'.format(
+                        single_reading['data'][single_reading['type']]['value']))
+
+                # Add sensor reading to result set.
+                fan_sensor_key = _translate_device_info(single_reading['scan_cache_device']['info'])
+                reading_value = single_reading['data'][single_reading['type']]['value']
+                if fan_sensor_key is not None and reading_value is not None:
+                    # Be sure not to overwrite any existing reading in the current result set.
+                    # That would imply a mapping issue or some other bug.
+                    if fan_sensor_key in new_readings['racks'][rack]:
+                        message = 'fan_sensors avoiding overwrite of existing reading [{}] at ' \
+                                  'new_readings[racks][{}][{}] with [{}]'.format(
+                                      new_readings['racks'][rack][fan_sensor_key],
+                                      rack, fan_sensor_key, reading_value)
+                        logger.error(message)
+                        raise ValueError(message)
+                    # No existing reading in the result set, safe to add it.
+                    new_readings['racks'][rack][fan_sensor_key] = reading_value
+
+
     logger.debug('--- FAN SENSORS end ---')
-    return readings
+    # Sort the new_readings racks by racks['id']
+    new_readings['racks'] = OrderedDict(sorted(new_readings['racks'].items()))
+    end_time = datetime.datetime.now()
+    read_time = (end_time - start_time).total_seconds() * 1000
+
+    # Shim in the start, end, read times into each response now that we have them.
+    # Even though they are all the same, they didn't used to be and auto fan wants
+    # each for logging purposes.
+    for rack in new_readings['racks']:
+        new_readings['racks'][rack]['start_time'] = str(start_time)
+        new_readings['racks'][rack]['end_time'] = str(end_time)
+        new_readings['racks'][rack]['read_time'] = read_time
+
+    return new_readings


### PR DESCRIPTION
This commit updates the fan_sensors route to make the result set look like what we had in synse 1.4 as much as possible. This makes the changes required for auto_fan much smaller.

Also sorts the scan cache racks to emit them in a predictable manner.

Sample result set:
start_time, end_time, read_time are the same for all vecs now. In the past they were not. Duplicating them in the result set makes the auto fan changes smaller.
```
vapor@vec1-c1-wrigley:~/src/vec-testbed/poc$ curl http://${SYNSE_IP}:5000/synse/2.0/fan_sensors
{
  "racks":{
    "vec1-c1-wrigley":{
      "thermistor_1":17.71,
      "thermistor_2":18.0,
      "thermistor_3":17.27,
      "thermistor_5":18.65,
      "thermistor_6":19.2,
      "thermistor_7":17.56,
      "thermistor_9":17.49,
      "thermistor_10":17.49,
      "thermistor_11":17.34,
      "differential_pressure_0":-6.333,
      "differential_pressure_1":32.194,
      "differential_pressure_2":1.742,
      "start_time":"2018-03-30 16:52:30.481019",
      "end_time":"2018-03-30 16:52:30.735985",
      "read_time":254.966
    },
    "vec2-c1-wrigley":{
      "thermistor_1":17.34,
      "thermistor_2":16.97,
      "thermistor_3":16.9,
      "thermistor_5":17.19,
      "thermistor_6":16.97,
      "thermistor_7":17.04,
      "thermistor_9":17.04,
      "thermistor_10":16.97,
      "thermistor_11":16.9,
      "differential_pressure_0":3.431,
      "differential_pressure_1":16.097,
      "differential_pressure_2":2.428,
      "start_time":"2018-03-30 16:52:30.481019",
      "end_time":"2018-03-30 16:52:30.735985",
      "read_time":254.966
    },
    "vec3-c1-wrigley":{
      "thermistor_1":16.9,
      "thermistor_2":16.6,
      "thermistor_3":16.68,
      "thermistor_5":17.04,
      "thermistor_6":17.19,
      "thermistor_7":16.9,
      "thermistor_9":16.6,
      "thermistor_10":16.68,
      "thermistor_11":16.6,
      "differential_pressure_0":183.033,
      "differential_pressure_1":110.728,
      "differential_pressure_2":63.175,
      "start_time":"2018-03-30 16:52:30.481019",
      "end_time":"2018-03-30 16:52:30.735985",
      "read_time":254.966
    },
    "vec4-c1-wrigley":{
      "thermistor_1":16.97,
      "thermistor_2":16.68,
      "thermistor_3":17.04,
      "thermistor_5":17.71,
      "thermistor_6":19.9,
      "thermistor_7":17.12,
      "thermistor_9":17.04,
      "thermistor_10":16.68,
      "thermistor_11":16.9,
      "differential_pressure_0":-1324.986,
      "differential_pressure_1":1047.428,
      "differential_pressure_2":294.869,
      "start_time":"2018-03-30 16:52:30.481019",
      "end_time":"2018-03-30 16:52:30.735985",
      "read_time":254.966
    },
    "vec5-c1-wrigley":{
      "thermistor_1":17.34,
      "thermistor_2":17.19,
      "thermistor_3":17.04,
      "thermistor_5":17.34,
      "thermistor_6":17.41,
      "thermistor_7":16.82,
      "thermistor_9":17.12,
      "thermistor_10":16.9,
      "thermistor_11":16.97,
      "differential_pressure_0":-8.022,
      "differential_pressure_1":477.006,
      "differential_pressure_2":46.233,
      "start_time":"2018-03-30 16:52:30.481019",
      "end_time":"2018-03-30 16:52:30.735985",
      "read_time":254.966
    },
    "vec6-c1-wrigley":{
      "thermistor_1":17.19,
      "thermistor_2":17.04,
      "thermistor_3":17.19,
      "thermistor_5":17.27,
      "thermistor_6":17.19,
      "thermistor_7":17.12,
      "thermistor_9":17.19,
      "thermistor_10":17.19,
      "thermistor_11":17.27,
      "differential_pressure_0":0.0,
      "differential_pressure_1":0.0,
      "differential_pressure_2":0.0,
      "start_time":"2018-03-30 16:52:30.481019",
      "end_time":"2018-03-30 16:52:30.735985",
      "read_time":254.966
    }
  }
}
```