### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,16 @@ jobs:
           command: |
             sudo chown -R circleci:circleci /usr/local/bin
             sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
-            pip install tox>=2.9.0
+            pip install tox>=2.9.0 codecov>=1.4.0
       - restore_cache:
           keys:
             - v1.5-tox-test-cache-{{ checksum "requirements.txt" }}-{{ checksum "tox.ini" }}
       - run:
           name: Unit Tests
           command: make test-unit
+      - run:
+          name: Unit Test Coverage
+          command: codecov
       - run:
           name: Integration Tests
           command: make test-integration

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <p align="center"><img src="assets/logo.png" width="360"></p>
 <p align="center">
     <a href="https://circleci.com/gh/vapor-ware/synse-server"><img src="https://circleci.com/gh/vapor-ware/synse-server.svg?style=shield"></a>
+    <a href="https://codecov.io/gh/vapor-ware/synse-server"><img src="https://codecov.io/gh/vapor-ware/synse-server/branch/master/graph/badge.svg" /></a>
         
 <h1 align="center">Synse Server</h1>
 </p>


### PR DESCRIPTION
fixes #99

This sets up codecov, uploads Synse Server's coverage report on test in CI, and adds the coverage badge to the README. This gives us better visibility into test coverage.