### PR TITLE
remove babel dependency from synse package, move it to tox workflow

### DIFF
--- a/dockerfile/release.dockerfile
+++ b/dockerfile/release.dockerfile
@@ -22,7 +22,7 @@ RUN set -e -x \
         bash libstdc++ \
     && apk --update --no-cache --virtual .build-dep add \
         curl build-base jq \
-    && pip install --upgrade pip babel \
+    && pip install --upgrade pip \
     && pip install -r requirements.txt \
     && bin_url=$(curl -s https://api.github.com/repos/${EMULATOR_REPO}/releases/latest | jq '.assets[] | select(.name == env.EMULATOR_BIN) | .url' | tr -d '"') \
     && curl -L -H "Accept: application/octet-stream" -o $EMULATOR_BIN $bin_url \

--- a/dockerfile/slim.dockerfile
+++ b/dockerfile/slim.dockerfile
@@ -8,7 +8,7 @@ RUN set -e -x \
         bash libstdc++ \
     && apk --update --no-cache --virtual .build-dep add \
         build-base \
-    && pip install --upgrade pip babel \
+    && pip install --upgrade pip \
     && pip install -r requirements.txt \
     && apk del .build-dep
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,16 +5,3 @@ universal = 1
 not_skip = __init__.py
 default_section = THIRDPARTY
 known_first_party = synse,tests
-
-[extract_messages]
-keywords = gettext
-input_dirs = synse
-output_file = synse/i18n/messages.pot
-
-[init_catalog]
-input_file = synse/i18n/messages.pot
-output_dir = synse/i18n
-locale = en_US
-
-[compile_catalog]
-directory = synse/i18n

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 
 import os
 
-from babel.messages import frontend as babel
 from setuptools import find_packages, setup
 
 
@@ -49,10 +48,5 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
-    ],
-    cmdclass={
-        'compile_catalog': babel.compile_catalog,
-        'extract_messages': babel.extract_messages,
-        'init_catalog': babel.init_catalog,
-    }
+    ]
 )

--- a/synse/i18n/en_US/LC_MESSAGES/messages.po
+++ b/synse/i18n/en_US/LC_MESSAGES/messages.po
@@ -1,14 +1,14 @@
-# English (United States) translations for synse.
+# English (United States) translations for PROJECT.
 # Copyright (C) 2018 ORGANIZATION
-# This file is distributed under the same license as the synse project.
+# This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: synse 2.0.0\n"
+"Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-04-16 09:13-0400\n"
-"PO-Revision-Date: 2018-04-16 09:13-0400\n"
+"POT-Creation-Date: 2018-04-16 11:31-0400\n"
+"PO-Revision-Date: 2018-04-16 11:31-0400\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en_US\n"
 "Language-Team: en_US <LL@li.org>\n"
@@ -126,12 +126,16 @@ msgstr ""
 msgid "plugin \"{}\" already exists - will not re-register (tcp)"
 msgstr ""
 
-#: synse/validate.py:25
+#: synse/validate.py:27
 msgid "Device ({}) is not of type {}"
 msgstr ""
 
-#: synse/routes/aliases.py:163 synse/routes/aliases.py:169 synse/validate.py:50
+#: synse/routes/aliases.py:163 synse/routes/aliases.py:169 synse/validate.py:52
 msgid "Invalid query param: {} (valid params: {})"
+msgstr ""
+
+#: synse/validate.py:73
+msgid "Endpoint does not support query parameters but got: {}"
 msgstr ""
 
 #: synse/commands/info.py:23
@@ -264,15 +268,15 @@ msgstr ""
 msgid "forcing re-scan? {}"
 msgstr ""
 
-#: synse/routes/core.py:93
+#: synse/routes/core.py:95
 msgid "Invalid JSON specified: {}"
 msgstr ""
 
-#: synse/routes/core.py:96
+#: synse/routes/core.py:98
 msgid "WRITE -> json: {}"
 msgstr ""
 
-#: synse/routes/core.py:100
+#: synse/routes/core.py:102
 msgid "Invalid data POSTed for write. Must contain \"action\" and/or \"raw\"."
 msgstr ""
 

--- a/synse/i18n/messages.pot
+++ b/synse/i18n/messages.pot
@@ -1,14 +1,14 @@
-# Translations template for synse.
+# Translations template for PROJECT.
 # Copyright (C) 2018 ORGANIZATION
-# This file is distributed under the same license as the synse project.
+# This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: synse 2.0.0\n"
+"Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-04-16 09:13-0400\n"
+"POT-Creation-Date: 2018-04-16 11:31-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -125,12 +125,16 @@ msgstr ""
 msgid "plugin \"{}\" already exists - will not re-register (tcp)"
 msgstr ""
 
-#: synse/validate.py:25
+#: synse/validate.py:27
 msgid "Device ({}) is not of type {}"
 msgstr ""
 
-#: synse/routes/aliases.py:163 synse/routes/aliases.py:169 synse/validate.py:50
+#: synse/routes/aliases.py:163 synse/routes/aliases.py:169 synse/validate.py:52
 msgid "Invalid query param: {} (valid params: {})"
+msgstr ""
+
+#: synse/validate.py:73
+msgid "Endpoint does not support query parameters but got: {}"
 msgstr ""
 
 #: synse/commands/info.py:23
@@ -263,15 +267,15 @@ msgstr ""
 msgid "forcing re-scan? {}"
 msgstr ""
 
-#: synse/routes/core.py:93
+#: synse/routes/core.py:95
 msgid "Invalid JSON specified: {}"
 msgstr ""
 
-#: synse/routes/core.py:96
+#: synse/routes/core.py:98
 msgid "WRITE -> json: {}"
 msgstr ""
 
-#: synse/routes/core.py:100
+#: synse/routes/core.py:102
 msgid "Invalid data POSTed for write. Must contain \"action\" and/or \"raw\"."
 msgstr ""
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,5 +58,5 @@ basepython=
 deps=
     Babel>=2.5.3
 commands=
-    python setup.py extract_messages
-    python setup.py init_catalog
+    pybabel extract -k gettext -o synse/i18n/messages.pot synse
+    pybabel init -i synse/i18n/messages.pot -d synse/i18n -l en_US


### PR DESCRIPTION
fixes #140 

This removes the `babel` package dependency in the python package, since it is only used in development. it moves the pieces that use babel to a tox job.