### PR TITLE
maintainer key is deprecated - use labels instead

### DIFF
--- a/dockerfile/release.dockerfile
+++ b/dockerfile/release.dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.6-alpine
-MAINTAINER Vapor IO <vapor@vapor.io>
+
+LABEL maintainer="vapor@vapor.io"
 
 # Environment variables for downloading the emulator plugin
 ENV EMULATOR_REPO vapor-ware/synse-emulator-plugin

--- a/dockerfile/slim.dockerfile
+++ b/dockerfile/slim.dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.6-alpine
-MAINTAINER Vapor IO <vapor@vapor.io>
+
+LABEL maintainer="vapor@vapor.io"
 
 COPY requirements.txt requirements.txt
 

--- a/dockerfile/test.dockerfile
+++ b/dockerfile/test.dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.6-alpine
-MAINTAINER Vapor IO <vapor@vapor.io>
+
+LABEL maintainer="vapor@vapor.io"
 
 RUN apk add --update \
   alpine-sdk \


### PR DESCRIPTION
small change, but according to the docker docs, `MAINTAINER` is deprecated and it says to use labels instead.