### PR TITLE
add labels do dockerfiles, consolidate some layers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 #
 PKG_NAME := synse
 IMG_NAME := vaporio/synse-server
-PKG_VER := $(shell python -c "import synse ; print(synse.__version__)")
+PKG_VER  := $(shell python -c "import synse ; print(synse.__version__)")
+DATE     := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 export GIT_VER := $(shell /bin/sh -c "git log --pretty=format:'%h' -n 1 || echo 'none'")
 
 
@@ -55,14 +56,22 @@ pycache-clean:
 docker-slim:
 	tags="" ; \
 	for tag in $(SLIM_TAGS); do tags="$${tags} -t $${tag}"; done ; \
-	docker build -f dockerfile/slim.dockerfile $${tags} .
+	docker build -f dockerfile/slim.dockerfile \
+		--build-arg BUILD_DATE=$(DATE) \
+		--build-arg BUILD_VERSION=$(PKG_VER) \
+		--build-arg VCS_REF=$(GIT_VER) \
+		$${tags} .
 
 # build the docker images of synse server with the emulator
 .PHONY: docker-default
 docker-default:
 	tags="" ; \
 	for tag in $(DEFAULT_TAGS); do tags="$${tags} -t $${tag}"; done ; \
-	docker build -f dockerfile/release.dockerfile $${tags} .
+	docker build -f dockerfile/release.dockerfile \
+		--build-arg BUILD_DATE=$(DATE) \
+		--build-arg BUILD_VERSION=$(PKG_VER) \
+		--build-arg VCS_REF=$(GIT_VER) \
+		$${tags} .
 
 
 # Targets

--- a/bin/install_emulator.sh
+++ b/bin/install_emulator.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# install_emulator.sh
+#
+# This script is used to install the latest release of the emulator
+# plugin into the current working directory. This is used in the
+# Synse Server Dockerfile, but can also be run locally.
+#
+# This script requires `curl` and `jq` to be installed.
+#
+# The following environment variables can be used with the script
+# to modify the default behavior:
+#   EMULATOR_BIN - the name of the emulator binary to download. see
+#      https://github.com/vapor-ware/synse-emulator-plugin/releases
+#      for the names of all available assets. (default: emulator_linux_amd64)
+#   EMULATOR_OUT - the path to output the downloaded binary
+#      (default: `./$EMULATOR_BIN`)
+#
+set -o errexit -o pipefail
+
+EMULATOR_REPO=vapor-ware/synse-emulator-plugin
+
+EMULATOR_BIN=${EMULATOR_BIN:-"emulator_linux_amd64"}
+EMULATOR_OUT=${EMULATOR_OUT:-""}
+
+# Get the GitHub release data for the Synse Emulator Plugin repo.
+data=$(curl -s https://api.github.com/repos/${EMULATOR_REPO}/releases/latest)
+
+# Get the URL for the latest release asset binary.
+bin_url=$(echo ${data} | jq --arg bin "$EMULATOR_BIN" '.assets[] | select(.name == $bin) | .url' | tr -d '"')
+
+# Download the binary
+curl -L -H "Accept: application/octet-stream" -o ${EMULATOR_BIN} ${bin_url}
+chmod +x ${EMULATOR_BIN}
+
+if [ "$EMULATOR_OUT" ]; then
+    mv ${EMULATOR_BIN} ${EMULATOR_OUT}
+fi

--- a/dockerfile/release.dockerfile
+++ b/dockerfile/release.dockerfile
@@ -1,44 +1,49 @@
 FROM python:3.6-alpine
-
 LABEL maintainer="vapor@vapor.io"
 
-# Environment variables for downloading the emulator plugin
-ENV EMULATOR_REPO vapor-ware/synse-emulator-plugin
-ENV EMULATOR_BIN  emulator_linux_amd64
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG VCS_REF
 
 # Environment variables for built-in emulator configuration.
-ENV PLUGIN_DEVICE_CONFIG /synse/emulator/config
-ENV PLUGIN_CONFIG /synse/emulator
+ENV PLUGIN_DEVICE_CONFIG="/synse/emulator/config" \
+    PLUGIN_CONFIG="/synse/emulator"
 
-COPY ./requirements.txt requirements.txt
+COPY requirements.txt requirements.txt
+COPY bin/install_emulator.sh tmp/install_emulator.sh
 
 # The linux_amd64 emulator binary is built with libc, not muslc, it
 # will not work here. The musl and glibc so files are compatible, so
 # we can make a symlink to fix the missing dependency:
 # https://stackoverflow.com/a/35613430
-RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
-
 RUN set -e -x \
+    && mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 \
     && apk --update --no-cache add \
         bash libstdc++ \
     && apk --update --no-cache --virtual .build-dep add \
         curl build-base jq \
     && pip install --upgrade pip \
     && pip install -r requirements.txt \
-    && bin_url=$(curl -s https://api.github.com/repos/${EMULATOR_REPO}/releases/latest | jq '.assets[] | select(.name == env.EMULATOR_BIN) | .url' | tr -d '"') \
-    && curl -L -H "Accept: application/octet-stream" -o $EMULATOR_BIN $bin_url \
-    && chmod +x $EMULATOR_BIN \
-    && mv $EMULATOR_BIN /usr/local/bin/emulator \
+    && EMULATOR_OUT=/usr/local/bin/emulator ./tmp/install_emulator.sh \
     && apk del .build-dep
+
+# Image Metadata -- http://label-schema.org/rc1/
+# This is set after the dependency install so we can cache that layer
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="vaporio/synse-server" \
+      org.label-schema.vcs-url="https://github.com/vapor-ware/synse-server" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vendor="Vapor IO" \
+      org.label-schema.version=$BUILD_VERSION
 
 COPY . /synse
 WORKDIR /synse
 
-# Create directories for plugin sockets and configuration
+# Create directories for plugin sockets and configuration, then
+# install Synse Server as a python package
 RUN mkdir -p /tmp/synse/procs \
-    && mkdir -p /synse/config
-
-# install synse_server python package
-RUN python setup.py install
+    && mkdir -p /synse/config \
+    && python setup.py install
 
 ENTRYPOINT ["bin/synse.sh"]

--- a/dockerfile/slim.dockerfile
+++ b/dockerfile/slim.dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.6-alpine
-
 LABEL maintainer="vapor@vapor.io"
+
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG VCS_REF
 
 COPY requirements.txt requirements.txt
 
@@ -13,14 +16,23 @@ RUN set -e -x \
     && pip install -r requirements.txt \
     && apk del .build-dep
 
+# Image Metadata -- http://label-schema.org/rc1/
+# This is set after the dependency install so we can cache that layer
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="vaporio/synse-server" \
+      org.label-schema.vcs-url="https://github.com/vapor-ware/synse-server" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vendor="Vapor IO" \
+      org.label-schema.version=$BUILD_VERSION
+
 COPY . /synse
 WORKDIR /synse
 
-# Create directories for plugin sockets and configuration
+# Create directories for plugin sockets and configuration, then
+# install Synse Server as a python package
 RUN mkdir -p /tmp/synse/procs \
-    && mkdir -p /synse/config
-
-# install synse_server python package
-RUN python setup.py install
+    && mkdir -p /synse/config \
+    && python setup.py install
 
 ENTRYPOINT ["bin/synse.sh"]


### PR DESCRIPTION
This adds labels to the Synse Server dockerfiles to provide some image/container metadata, such as the image build date, git commit, git repo, synse version, etc. This should be helpful if there are issues when someone is using "latest" and we need to know the exact build version, e.g.

This also does a little bit of cleanup and layer consolidation as per the dockerfile "best practices"