### PR TITLE
add a boot-target type

### DIFF
--- a/synse/const.py
+++ b/synse/const.py
@@ -3,12 +3,20 @@
 # QUESTION (etd) - should this be 'procs', or something else? perhaps 'run' or 'sock'
 SOCKET_DIR = '/tmp/synse/procs'
 
-# Device Types
+# Device type definitions
 TYPE_LED = 'led'
 TYPE_FAN = 'fan'
 TYPE_SYSTEM = 'system'
 TYPE_POWER = 'power'
 TYPE_LOCK = 'lock'
+TYPE_BOOT_TARGET = 'boot_target'
+
+# Type groupings (these correspond to API actions)
+LED_TYPES = [TYPE_LED]
+FAN_TYPES = [TYPE_FAN]
+POWER_TYPES = [TYPE_POWER]
+LOCK_TYPES = [TYPE_LOCK]
+BOOT_TARGET_TYPES = [TYPE_SYSTEM, TYPE_BOOT_TARGET]
 
 
 # LED state definitions

--- a/synse/routes/aliases.py
+++ b/synse/routes/aliases.py
@@ -33,7 +33,7 @@ async def led_route(request, rack, board, device):
     Returns:
         sanic.response.HTTPResponse: The endpoint response.
     """
-    await validate.validate_device_type(const.TYPE_LED, rack, board, device)
+    await validate.validate_device_type(const.LED_TYPES, rack, board, device)
 
     # Get the valid query parameters. If unsupported query parameters
     # are specified, this will raise an error.
@@ -115,7 +115,7 @@ async def fan_route(request, rack, board, device):
     Returns:
         sanic.response.HTTPResponse: The endpoint response.
     """
-    await validate.validate_device_type(const.TYPE_FAN, rack, board, device)
+    await validate.validate_device_type(const.FAN_TYPES, rack, board, device)
 
     # Get the valid query parameters. If unsupported query parameters
     # are specified, this will raise an error.
@@ -194,7 +194,7 @@ async def power_route(request, rack, board, device):
     Returns:
         sanic.response.HTTPResponse: The endpoint response.
     """
-    await validate.validate_device_type(const.TYPE_POWER, rack, board, device)
+    await validate.validate_device_type(const.POWER_TYPES, rack, board, device)
 
     # Get the valid query parameters. If unsupported query parameters
     # are specified, this will raise an error.
@@ -249,7 +249,7 @@ async def boot_target_route(request, rack, board, device):
     Returns:
         sanic.response.HTTPResponse: The endpoint response.
     """
-    await validate.validate_device_type(const.TYPE_SYSTEM, rack, board, device)
+    await validate.validate_device_type(const.BOOT_TARGET_TYPES, rack, board, device)
 
     # Get the valid query parameters. If unsupported query parameters
     # are specified, this will raise an error.

--- a/synse/validate.py
+++ b/synse/validate.py
@@ -10,8 +10,12 @@ async def validate_device_type(device_type, rack, board, device):
     """Validate that the device associated with the given routing info
     (rack, board device) matches the given device type.
 
+    This checks that the lower-cased device type matches the lower-cased
+    expected type, so casing on device type(s) should not matter.
+
     Args:
-        device_type (str): The type of the device, e.g. "led", "fan", etc.
+        device_type (list[str]): The device types that are permissible,
+            e.g. "led", "fan", etc.
         rack (str): The rack which the device belongs to.
         board (str): The board which the device belongs to.
         device (str): The ID of the device.
@@ -21,9 +25,9 @@ async def validate_device_type(device_type, rack, board, device):
         errors.DeviceNotFoundError: The specified device is not found.
     """
     __, device = await cache.get_device_meta(rack, board, device)  # pylint: disable=unused-variable
-    if device.type != device_type.lower():
+    if device.type.lower() not in [t.lower() for t in device_type]:
         raise errors.InvalidDeviceType(
-            _('Device ({}) is not of type {}').format(device.type, device_type)
+            _('Device ({}) is not a supported type {}').format(device.type, device_type)
         )
 
 

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -63,10 +63,14 @@ def patch_metainfo(monkeypatch):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     'device_type', [
-        'thermistor',
-        'Thermistor',
-        'THERMISTOR',
-        'ThErMiStOr',
+        ['thermistor'],
+        ['Thermistor'],
+        ['THERMISTOR'],
+        ['ThErMiStOr'],
+        # multiple types can be permissible for validation
+        ['led', 'fan', 'thermistor'],
+        ['system', 'THERMISTOR'],
+        ['LOCK', 'Thermistor']
     ]
 )
 async def test_validate_device_type(patch_metainfo, clear_caches, device_type):
@@ -78,14 +82,21 @@ async def test_validate_device_type(patch_metainfo, clear_caches, device_type):
 async def test_validate_device_type_no_device():
     """Test validating a device when the specified device doesn't exist."""
     with pytest.raises(errors.DeviceNotFoundError):
-        await validate.validate_device_type('thermistor', 'foo', 'bar', 'baz')
+        await validate.validate_device_type(['thermistor'], 'foo', 'bar', 'baz')
 
 
 @pytest.mark.asyncio
 async def test_validate_device_type_no_match(patch_metainfo, clear_caches):
     """Test validating a device when the types don't match."""
     with pytest.raises(errors.InvalidDeviceType):
-        await validate.validate_device_type('led', 'rack-1', 'vec', '12345')
+        await validate.validate_device_type(['led'], 'rack-1', 'vec', '12345')
+
+
+@pytest.mark.asyncio
+async def test_validate_device_type_no_match_multiple(patch_metainfo, clear_caches):
+    """Test validating a device when the types don't match."""
+    with pytest.raises(errors.InvalidDeviceType):
+        await validate.validate_device_type(['led', 'something'], 'rack-1', 'vec', '12345')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The `boot_target` endpoint previously checked that the device type was `system`. This adds a `boot_target` type, which is used by the IPMI plugin and will be used by the AMT plugin. 

It changes up the validation function to allow multiple types for an endpoint. Updates tests.

related to #153 