### PR TITLE
improve image build performance by sharing layers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ cover: test-unit ## Run unit tests and open the HTML coverage report
 	open ./results/cov-html/index.html
 
 .PHONY: docker
-docker: req-translations docker-default docker-slim ## Build the docker image for Synse Server locally
+docker: req-translations docker-slim docker-default ## Build the docker image for Synse Server locally
 
 .PHONY: api-doc
 api-doc: ## Open the API doc HTML reference

--- a/dockerfile/release.dockerfile
+++ b/dockerfile/release.dockerfile
@@ -1,12 +1,24 @@
-FROM python:3.6-alpine
-LABEL maintainer="vapor@vapor.io"
+#
+# release.dockerfile
+#
+# The dockerfile for the default Synse Server release. This image
+# contains Synse Server and a built-in plugin emulator. It is based
+# off of the synse-server:slim image (see slim.dockerfile), which
+# installs the Synse Server dependencies, leaving this Dockerfile to
+# only need to install the emulator.
+#
+# Note that because slim.dockerfile uses build args to set image metainfo,
+# the build cache is invalidated so this image will always be rebuilt.
+# The work done here should be minimal.
+#
+FROM vaporio/synse-server:slim
+
+# Emulator installation script
+COPY bin/install_emulator.sh tmp/install_emulator.sh
 
 # Environment variables for built-in emulator configuration.
 ENV PLUGIN_DEVICE_CONFIG="/synse/emulator/config" \
     PLUGIN_CONFIG="/synse/emulator"
-
-COPY requirements.txt requirements.txt
-COPY bin/install_emulator.sh tmp/install_emulator.sh
 
 # The linux_amd64 emulator binary is built with libc, not muslc, it
 # will not work here. The musl and glibc so files are compatible, so
@@ -14,36 +26,7 @@ COPY bin/install_emulator.sh tmp/install_emulator.sh
 # https://stackoverflow.com/a/35613430
 RUN set -e -x \
     && mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 \
-    && apk --update --no-cache add \
-        bash libstdc++ \
     && apk --update --no-cache --virtual .build-dep add \
-        curl build-base jq \
-    && pip install --upgrade pip \
-    && pip install -r requirements.txt \
+        curl jq \
     && EMULATOR_OUT=/usr/local/bin/emulator ./tmp/install_emulator.sh \
     && apk del .build-dep
-
-# Image Metadata -- http://label-schema.org/rc1/
-# This is set after the dependency install so we can cache that layer
-ARG BUILD_DATE
-ARG BUILD_VERSION
-ARG VCS_REF
-
-LABEL org.label-schema.schema-version="1.0" \
-      org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.name="vaporio/synse-server" \
-      org.label-schema.vcs-url="https://github.com/vapor-ware/synse-server" \
-      org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vendor="Vapor IO" \
-      org.label-schema.version=$BUILD_VERSION
-
-COPY . /synse
-WORKDIR /synse
-
-# Create directories for plugin sockets and configuration, then
-# install Synse Server as a python package
-RUN mkdir -p /tmp/synse/procs \
-    && mkdir -p /synse/config \
-    && python setup.py install
-
-ENTRYPOINT ["bin/synse.sh"]

--- a/dockerfile/slim.dockerfile
+++ b/dockerfile/slim.dockerfile
@@ -1,3 +1,11 @@
+#
+# slim.dockerfile
+#
+# The dockerfile for the slim Synse Server release. This image
+# contains Synse Server without the built-in plugin emulator. This
+# image serves as the base for release.dockerfile, so it should be
+# built first.
+#
 FROM python:3.6-alpine
 LABEL maintainer="vapor@vapor.io"
 


### PR DESCRIPTION
new pushes to master look like they can take from 9 minutes to 17 minutes when the images are rebuilt. 

this PR should improve build performance by having the release image based on the slim image (e.g. they share layers). Then instead of spending time installing the same dependencies twice (in particular, grpcio and uvloop take a while), we just do it once, so in theory this should halve the build time.