### PR TITLE
Fix bug in Docker image build flow allowing for out-of-date base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ docker-default:
 .PHONY: docker-slim
 # build the docker images for slim.dockerfile -- this does not include the emulator
 docker-slim:
+	# Build the 'vaporio/synse-server:base' image. This will be used as the base
+	# for the 'release' image.
+	@$(MAKE) build-docker IMAGE_TAGS=base IMAGE_DOCKERFILE=slim.dockerfile
+	# Tag the slim image with the appropriate '-slim' tags.
 	@$(MAKE) build-docker IMAGE_TAG_SUFFIX=slim IMAGE_DOCKERFILE=slim.dockerfile
 
 .PHONY: pycache-clean

--- a/bin/ci/build_and_publish.sh
+++ b/bin/ci/build_and_publish.sh
@@ -88,10 +88,6 @@ echo "All tags for ${IMAGE_NAME}: ${tags[@]}"
 # uses a Make target defined there.
 #
 
-# Since release.dockerfile is based off of vaporio/synse-server:slim, we
-# will want to to generate that tag here as well.
-IMAGE_TAGS=slim IMAGE_DOCKERFILE=slim.dockerfile make build-docker
-
 IMAGE_TAGS="${tags[@]}" make docker
 
 
@@ -115,5 +111,10 @@ images=($(docker images \
 echo "images to push: ${images}"
 
 for image in "${images[@]}"; do
-    docker push ${image}
+    # We want to not push the vaporio/synse-server:base image, since it is
+    # only built as the base for the release dockerfile and other tags. It
+    # is not intended to be pushed to DockerHub.
+    if [ "${image}" != "vaporio/synse-server:base" ]; then
+        docker push ${image}
+    fi
 done

--- a/dockerfile/release.dockerfile
+++ b/dockerfile/release.dockerfile
@@ -3,15 +3,20 @@
 #
 # The dockerfile for the default Synse Server release. This image
 # contains Synse Server and a built-in plugin emulator. It is based
-# off of the synse-server:slim image (see slim.dockerfile), which
+# off of the synse-server:base image (see slim.dockerfile), which
 # installs the Synse Server dependencies, leaving this Dockerfile to
 # only need to install the emulator.
+#
+# vaporio/synse-server:base is NOT in DockerHub, it is intended to be
+# a local artifact from building slim.dockerfile. This way, this Dockerfile
+# is not using outdated images as its base. This build artifact is created
+# via the 'docker-slim' target.
 #
 # Note that because slim.dockerfile uses build args to set image metainfo,
 # the build cache is invalidated so this image will always be rebuilt.
 # The work done here should be minimal.
 #
-FROM vaporio/synse-server:slim
+FROM vaporio/synse-server:base
 
 # Emulator installation script
 COPY bin/install_emulator.sh tmp/install_emulator.sh

--- a/synse/__init__.py
+++ b/synse/__init__.py
@@ -3,7 +3,7 @@ and virtual devices.
 """
 
 __title__ = 'synse'
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 __description__ = 'Synse Server'
 __author__ = 'Vapor IO'
 __author_email__ = 'vapor@vapor.io'


### PR DESCRIPTION
The `release.dockerfile` image was based on `vaporio/synse-server:slim`. The `slim` tag wasn't managed great in the build flow, and it also exists in DockerHub, so if it didn't get built locally with the latest version, it would reach out to DockerHub and pull the stale version.

This PR changes the base image tag to one that is explicitly not in DockerHub and adds in some checking/handling around it. 

The micro version is also bumped so we can create a new release and get correctly versioned images into DockerHub.