### PR TITLE
Change read scheme to allow multiple readings of the same type

### DIFF
--- a/docs/api/index.html.md
+++ b/docs/api/index.html.md
@@ -552,8 +552,8 @@ response = requests.get('http://host:5000/synse/2.1/read/rack-1/vec/eb100067acb0
 ```json
 {
   "type": "temperature",
-  "data": {
-    "temperature": {
+  "data": [
+    {
       "value": 20.3,
       "timestamp": "2018-02-01T13:47:40.395939895Z",
       "unit": {
@@ -563,7 +563,7 @@ response = requests.get('http://host:5000/synse/2.1/read/rack-1/vec/eb100067acb0
       "type": "temperature",
       "info": ""
     }
-  }
+  ]
 }
 ```
 
@@ -572,22 +572,22 @@ response = requests.get('http://host:5000/synse/2.1/read/rack-1/vec/eb100067acb0
 ```json
 {
   "type": "led",
-  "data": {
-    "state": {
+  "data": [
+    {
       "value": "off",
       "timestamp": "2018-02-01T13:48:59.573898829Z",
       "unit": null,
       "type": "state",
       "info": ""
     },
-    "color": {
+    {
       "value": "000000",
       "timestamp": "2018-02-01T13:48:59.573898829Z",
       "unit": null,
       "type": "color",
       "info": ""
     }
-  }
+  ]
 }
 ```
 
@@ -998,22 +998,22 @@ response = requests.get('http://host:5000/synse/2.1/led/rack-1/vec/f52d29fecf05a
 ```json
 {
   "type": "led",
-  "data": {
-    "state": {
+  "data": [
+    {
       "value": "off",
       "timestamp": "2018-02-01T16:16:04.884816422Z",
       "unit": null,
       "type": "state",
       "info": ""
     },
-    "color": {
+    {
       "value": "f38ac2",
       "timestamp": "2018-02-01T16:16:04.884816422Z",
       "unit": null,
       "type": "color",
       "info": ""
     }
-  }
+  ]
 }
 ```
 
@@ -1111,8 +1111,8 @@ response = requests.get('http://host:5000/synse/2.1/fan/rack-1/vec/eb9a56f95b5bd
 ```json
 {
   "type": "fan",
-  "data": {
-    "fan_speed": {
+  "data": [
+    {
       "value": 0,
       "timestamp": "2018-02-01T17:07:18.113960446Z",
       "unit": {
@@ -1122,7 +1122,7 @@ response = requests.get('http://host:5000/synse/2.1/fan/rack-1/vec/eb9a56f95b5bd
       "type": "fan_speed",
       "info": ""
     }
-  }
+  ]
 }
 ```
 
@@ -1212,15 +1212,15 @@ response = requests.get('http://host:5000/synse/2.1/power/rack-1/vec/fd8e4bd57f0
 ```json
 {
   "type": "power",
-  "data": {
-    "state": {
+  "data": [
+    {
       "value": "on",
       "timestamp": "2018-05-07T13:41:08.690629Z",
       "unit": null,
       "type": "state",
       "info": ""
     }
-  }
+  ]
 }
 ```
 
@@ -1314,15 +1314,15 @@ response = requests.get('http://host:5000/synse/2.1/boot_target/rack-1/vec/55882
 ```json
 {
   "type": "boot_target",
-  "data": {
-    "target": {
+  "data": [
+    {
       "value": "disk",
       "timestamp": "2018-05-07T13:59:53.5529982Z",
       "unit": null,
       "type": "target",
       "info": ""
     }
-  }
+  ]
 }
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -975,8 +975,8 @@ the given rack or board.</p>
 </blockquote>
 <pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
   </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"temperature"</span><span class="p">,</span><span class="w">
-  </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-    </span><span class="s2">"temperature"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+  </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+    </span><span class="p">{</span><span class="w">
       </span><span class="s2">"value"</span><span class="p">:</span><span class="w"> </span><span class="mf">20.3</span><span class="p">,</span><span class="w">
       </span><span class="s2">"timestamp"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2018-02-01T13:47:40.395939895Z"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"unit"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
@@ -986,7 +986,7 @@ the given rack or board.</p>
       </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"temperature"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"info"</span><span class="p">:</span><span class="w"> </span><span class="s2">""</span><span class="w">
     </span><span class="p">}</span><span class="w">
-  </span><span class="p">}</span><span class="w">
+  </span><span class="p">]</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre>
 <blockquote>
@@ -994,22 +994,22 @@ the given rack or board.</p>
 </blockquote>
 <pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
   </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"led"</span><span class="p">,</span><span class="w">
-  </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-    </span><span class="s2">"state"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+  </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+    </span><span class="p">{</span><span class="w">
       </span><span class="s2">"value"</span><span class="p">:</span><span class="w"> </span><span class="s2">"off"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"timestamp"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2018-02-01T13:48:59.573898829Z"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"unit"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
       </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"state"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"info"</span><span class="p">:</span><span class="w"> </span><span class="s2">""</span><span class="w">
     </span><span class="p">},</span><span class="w">
-    </span><span class="s2">"color"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+    </span><span class="p">{</span><span class="w">
       </span><span class="s2">"value"</span><span class="p">:</span><span class="w"> </span><span class="s2">"000000"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"timestamp"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2018-02-01T13:48:59.573898829Z"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"unit"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
       </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"color"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"info"</span><span class="p">:</span><span class="w"> </span><span class="s2">""</span><span class="w">
     </span><span class="p">}</span><span class="w">
-  </span><span class="p">}</span><span class="w">
+  </span><span class="p">]</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre>
 <p>Read data from a known device.</p>
@@ -1536,22 +1536,22 @@ a rack-level request:</p>
 </blockquote>
 <pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
   </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"led"</span><span class="p">,</span><span class="w">
-  </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-    </span><span class="s2">"state"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+  </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+    </span><span class="p">{</span><span class="w">
       </span><span class="s2">"value"</span><span class="p">:</span><span class="w"> </span><span class="s2">"off"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"timestamp"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2018-02-01T16:16:04.884816422Z"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"unit"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
       </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"state"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"info"</span><span class="p">:</span><span class="w"> </span><span class="s2">""</span><span class="w">
     </span><span class="p">},</span><span class="w">
-    </span><span class="s2">"color"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+    </span><span class="p">{</span><span class="w">
       </span><span class="s2">"value"</span><span class="p">:</span><span class="w"> </span><span class="s2">"f38ac2"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"timestamp"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2018-02-01T16:16:04.884816422Z"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"unit"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
       </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"color"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"info"</span><span class="p">:</span><span class="w"> </span><span class="s2">""</span><span class="w">
     </span><span class="p">}</span><span class="w">
-  </span><span class="p">}</span><span class="w">
+  </span><span class="p">]</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre>
 <blockquote>
@@ -1656,8 +1656,8 @@ of valid query parameters are specified, the endpoint will write to the specifie
 </blockquote>
 <pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
   </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"fan"</span><span class="p">,</span><span class="w">
-  </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-    </span><span class="s2">"fan_speed"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+  </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+    </span><span class="p">{</span><span class="w">
       </span><span class="s2">"value"</span><span class="p">:</span><span class="w"> </span><span class="mi">0</span><span class="p">,</span><span class="w">
       </span><span class="s2">"timestamp"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2018-02-01T17:07:18.113960446Z"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"unit"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
@@ -1667,7 +1667,7 @@ of valid query parameters are specified, the endpoint will write to the specifie
       </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"fan_speed"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"info"</span><span class="p">:</span><span class="w"> </span><span class="s2">""</span><span class="w">
     </span><span class="p">}</span><span class="w">
-  </span><span class="p">}</span><span class="w">
+  </span><span class="p">]</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre>
 <blockquote>
@@ -1765,15 +1765,15 @@ of valid query parameters are specified, the endpoint will write to the specifie
 </blockquote>
 <pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
   </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"power"</span><span class="p">,</span><span class="w">
-  </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-    </span><span class="s2">"state"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+  </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+    </span><span class="p">{</span><span class="w">
       </span><span class="s2">"value"</span><span class="p">:</span><span class="w"> </span><span class="s2">"on"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"timestamp"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2018-05-07T13:41:08.690629Z"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"unit"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
       </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"state"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"info"</span><span class="p">:</span><span class="w"> </span><span class="s2">""</span><span class="w">
     </span><span class="p">}</span><span class="w">
-  </span><span class="p">}</span><span class="w">
+  </span><span class="p">]</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre>
 <blockquote>
@@ -1871,15 +1871,15 @@ and <code>cycle</code>.</p>
 </blockquote>
 <pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
   </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"boot_target"</span><span class="p">,</span><span class="w">
-  </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-    </span><span class="s2">"target"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+  </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+    </span><span class="p">{</span><span class="w">
       </span><span class="s2">"value"</span><span class="p">:</span><span class="w"> </span><span class="s2">"disk"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"timestamp"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2018-05-07T13:59:53.5529982Z"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"unit"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
       </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"target"</span><span class="p">,</span><span class="w">
       </span><span class="s2">"info"</span><span class="p">:</span><span class="w"> </span><span class="s2">""</span><span class="w">
     </span><span class="p">}</span><span class="w">
-  </span><span class="p">}</span><span class="w">
+  </span><span class="p">]</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre>
 <blockquote>

--- a/synse/scheme/read.py
+++ b/synse/scheme/read.py
@@ -11,8 +11,10 @@ class ReadResponse(SynseResponse):
     Response Example:
         {
           "type": "humidity",
-          "data": {
-            "temperature": {
+          "data": [
+            {
+              "info": "",
+              "type": "temperature",
               "value": 123,
               "unit": {
                 "symbol": "C",
@@ -20,7 +22,9 @@ class ReadResponse(SynseResponse):
               },
               "timestamp": "2017-11-10 09:08:07"
             },
-            "humidity": {
+            {
+              "info": "",
+              "type": "humidity",
               "value": 123,
               "unit": {
                 "symbol": "%",
@@ -28,7 +32,7 @@ class ReadResponse(SynseResponse):
               },
               "timestamp": "2017-11-10 09:08:07"
             }
-          }
+          ]
         }
 
     Args:
@@ -53,7 +57,7 @@ class ReadResponse(SynseResponse):
             dict: A properly formatted Read response.
         """
         logger.debug(_('Formatting read response'))
-        formatted = {}
+        formatted = []
 
         dev_output = self.device.output
         for reading in self.readings:
@@ -112,12 +116,12 @@ class ReadResponse(SynseResponse):
                 if precision and isinstance(value, float):
                     value = round(value, precision)
 
-            formatted[rt] = {
+            formatted.append({
                 'value': value,
                 'timestamp': reading.timestamp,
                 'unit': unit,
                 'type': rt,
                 'info': reading.info,
-            }
+            })
 
         return formatted

--- a/tests/end_to_end/test_synse.py
+++ b/tests/end_to_end/test_synse.py
@@ -210,9 +210,14 @@ def validate_read(data):
     if keys is None:
         pytest.fail('Reading type unknown: {}'.format(data))
 
-    assert isinstance(d, dict)
+    assert isinstance(d, list)
     for k in keys:
-        assert k in d
+        found = False
+        for reading in d:
+            if reading['type'] == k:
+                found = True
+                break
+        assert found
 
 
 def validate_error_response(data, http_code, error_code):

--- a/tests/unit/commands/test_read_command.py
+++ b/tests/unit/commands/test_read_command.py
@@ -193,8 +193,8 @@ async def test_read_command_grpc_err_no_reading(mock_get_device_info, mock_clien
     assert isinstance(resp, ReadResponse)
     assert resp.data == {
         'kind': 'thermistor',
-        'data': {
-            'temperature': {
+        'data': [
+            {
                 'info': '',
                 'type': 'temperature',
                 'value': None,
@@ -204,7 +204,7 @@ async def test_read_command_grpc_err_no_reading(mock_get_device_info, mock_clien
                     'symbol': 'C'
                 }
             }
-        }
+        ]
     }
 
 
@@ -217,8 +217,8 @@ async def test_read_command(mock_get_device_info, mock_client_read, make_plugin)
     assert isinstance(resp, ReadResponse)
     assert resp.data == {
         'kind': 'thermistor',
-        'data': {
-            'temperature': {
+        'data': [
+            {
                 'info': '',
                 'type': 'temperature',
                 'value': 10.0,
@@ -228,5 +228,5 @@ async def test_read_command(mock_get_device_info, mock_client_read, make_plugin)
                     'symbol': 'C'
                 }
             }
-        }
+        ]
     }

--- a/tests/unit/scheme/test_read_scheme.py
+++ b/tests/unit/scheme/test_read_scheme.py
@@ -51,8 +51,8 @@ def test_read_scheme():
 
     assert response_scheme.data == {
         'kind': 'thermistor',
-        'data': {
-            'temperature': {
+        'data': [
+            {
                 'info': '',
                 'type': 'temperature',
                 'value': 10.0,
@@ -62,7 +62,7 @@ def test_read_scheme():
                     'symbol': 'C'
                 }
             }
-        }
+        ]
     }
 
 
@@ -82,8 +82,8 @@ def test_read_scheme_empty_value():
 
     assert response_scheme.data == {
         'kind': 'thermistor',
-        'data': {
-            'temperature': {
+        'data': [
+            {
                 'info': '',
                 'type': 'temperature',
                 'value': None,
@@ -93,7 +93,7 @@ def test_read_scheme_empty_value():
                     'symbol': 'C'
                 }
             }
-        }
+        ]
     }
 
 
@@ -128,8 +128,8 @@ def test_read_scheme_non_convertible_value():
 
     assert response_scheme.data == {
         'kind': 'thermistor',
-        'data': {
-            'temperature': {
+        'data': [
+            {
                 'info': '',
                 'type': 'temperature',
                 'value': '101a',
@@ -139,7 +139,7 @@ def test_read_scheme_non_convertible_value():
                     'symbol': 'C'
                 }
             }
-        }
+        ]
     }
 
 
@@ -159,8 +159,8 @@ def test_read_scheme_with_precision_rounding():
 
     assert response_scheme.data == {
         'kind': 'thermistor',
-        'data': {
-            'temperature': {
+        'data': [
+            {
                 'info': '',
                 'value': 10.123,
                 'type': 'temperature',
@@ -170,7 +170,7 @@ def test_read_scheme_with_precision_rounding():
                     'symbol': 'C'
                 }
             }
-        }
+        ]
     }
 
 
@@ -190,8 +190,8 @@ def test_read_scheme_with_precision_rounding_2():
 
     assert response_scheme.data == {
         'kind': 'thermistor',
-        'data': {
-            'temperature': {
+        'data': [
+            {
                 'info': '',
                 'type': 'temperature',
                 'value': 10.988,
@@ -201,7 +201,7 @@ def test_read_scheme_with_precision_rounding_2():
                     'symbol': 'C'
                 }
             }
-        }
+        ]
     }
 
 
@@ -221,7 +221,7 @@ def test_read_scheme_with_no_matching_readings():
 
     assert response_scheme.data == {
         'kind': 'thermistor',
-        'data': {}
+        'data': []
     }
 
 
@@ -243,15 +243,15 @@ def test_read_scheme_no_unit():
 
     assert response_scheme.data == {
         'kind': 'thermistor',
-        'data': {
-            'temperature': {
+        'data': [
+            {
                 'info': '',
                 'type': 'temperature',
                 'value': 10.988,
                 'timestamp': 'november',
                 'unit': None
             }
-        }
+        ]
     }
 
 
@@ -272,8 +272,8 @@ def test_read_scheme_no_precision():
 
     assert response_scheme.data == {
         'kind': 'thermistor',
-        'data': {
-            'temperature': {
+        'data': [
+            {
                 'info': '',
                 'type': 'temperature',
                 'value': 10.98765432,
@@ -283,5 +283,5 @@ def test_read_scheme_no_precision():
                     'symbol': 'C'
                 }
             }
-        }
+        ]
     }


### PR DESCRIPTION
fixes #177 

The need for this was made known by updating the modbus-ip plugin, where the eGauge device will have multiple voltage readings. Previously, only one would show up because the other readings would get overridden in the dict. Now, the reading data is a list so multiple readings of the same type can coexist, e.g.

```
edaniszewski ~ ➜ curl localhost:5000/synse/2.1/read/rack-1/board-1/03375594c959ddafa53ab057d78e5f59
{
  "kind":"input_register",
  "data":[
    {
      "value":122.836,
      "timestamp":"2018-06-22T17:20:23.1707345Z",
      "unit":{
        "symbol":"V",
        "name":"volt"
      },
      "type":"voltage",
      "info":"Leg 1 to neutral RMS voltage"
    },
    {
      "value":2.304,
      "timestamp":"2018-06-22T17:20:23.2169122Z",
      "unit":{
        "symbol":"V",
        "name":"volt"
      },
      "type":"voltage",
      "info":"Leg 2 to neutral RMS voltage"
    },
    {
      "value":122.765,
      "timestamp":"2018-06-22T17:20:23.2510255Z",
      "unit":{
        "symbol":"V",
        "name":"volt"
      },
      "type":"voltage",
      "info":"Leg 1 to Leg 2 RMS voltage"
    }
  ]
}
```

pinging @MatthewHink @Kontazler @hoanhan101 since I believe you are all using this sdk1.0 branch of synse server for various things. 