### PR TITLE
Fix build args for old docker versions

### DIFF
--- a/dockerfile/release.dockerfile
+++ b/dockerfile/release.dockerfile
@@ -18,7 +18,7 @@
 #
 FROM vaporio/synse-server:base
 
-# Build Image Metadata. Mapping after slim.dockerfile.
+# Set Image Metadata (mapping after dockerfile/slim.dockerfile).
 ARG BUILD_DATE
 ARG BUILD_VERSION
 ARG VCS_REF

--- a/dockerfile/release.dockerfile
+++ b/dockerfile/release.dockerfile
@@ -18,6 +18,19 @@
 #
 FROM vaporio/synse-server:base
 
+# Build Image Metadata. Mapping after slim.dockerfile.
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG VCS_REF
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="vaporio/synse-server" \
+      org.label-schema.vcs-url="https://github.com/vapor-ware/synse-server" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vendor="Vapor IO" \
+      org.label-schema.version=$BUILD_VERSION
+
 # Emulator installation script
 COPY bin/install_emulator.sh tmp/install_emulator.sh
 


### PR DESCRIPTION
Due to the conversation at #182 with @edaniszewski, it seems like old docker versions don't allow build args to be passed in if they aren't consumed. This PR follows the suggestion to include the image metadata setting (that we have in the `dockerfile/slim.dockerfile`) in `dockerfile/release.dockerfile` to make a successfully build.