### PR TITLE
scan output should have type, not kind

### DIFF
--- a/synse/cache.py
+++ b/synse/cache.py
@@ -530,7 +530,7 @@ def _build_scan_cache(device_info):
                     {
                         'id': device_id,
                         'info': source.info,
-                        'type': source.kind
+                        'type': utils.type_from_kind(source.kind)
                     }
                 ]
             }
@@ -563,7 +563,7 @@ def _build_scan_cache(device_info):
                         {
                             'id': device_id,
                             'info': source.info,
-                            'type': source.kind
+                            'type': utils.type_from_kind(source.kind)
                         }
                     ]
                 }
@@ -574,7 +574,7 @@ def _build_scan_cache(device_info):
                 r['boards'][board_id]['devices'].append({
                     'id': device_id,
                     'info': source.info,
-                    'type': source.kind
+                    'type': utils.type_from_kind(source.kind)
                 })
 
     if _tracked:

--- a/synse/scheme/scan.py
+++ b/synse/scheme/scan.py
@@ -7,39 +7,47 @@ class ScanResponse(SynseResponse):
     """A ScanResponse is the response data for a Synse 'scan' command.
 
     Response Example:
-        {
-          "timestamp": "2017-11-10 10:13:45",
-          "racks": [
+        "racks": [
             {
-              "rack_id": "rack_1",
+              "id": "rack-1",
               "boards": [
                 {
-                  "board_id": "5001000d",
+                  "id": "vec",
                   "devices": [
                     {
-                      "device_id": "0001",
-                      "device_info": "Rack Differential Pressure Middle",
-                      "device_type": "pressure"
-                    }
-                  ]
-                },
-                {
-                  "board_id": "5001000f",
-                  "devices": [
+                      "id": "eb100067acb0c054cf877759db376b03",
+                      "info": "Synse Temperature Sensor 1",
+                      "type": "temperature"
+                    },
                     {
-                      "device_id": "0001",
-                      "device_info": "Rack LED",
-                      "device_type": "vapor_led"
-                    }
-                  ]
-                },
-                {
-                  "board_id": "50000001",
-                  "devices": [
+                      "id": "83cc1efe7e596e4ab6769e0c6e3edf88",
+                      "info": "Synse Temperature Sensor 2",
+                      "type": "temperature"
+                    },
                     {
-                      "device_id": "0001",
-                      "device_info": "cec temperature and humidity",
-                      "device_type": "humidity"
+                      "id": "329a91c6781ce92370a3c38ba9bf35b2",
+                      "info": "Synse Temperature Sensor 4",
+                      "type": "temperature"
+                    },
+                    {
+                      "id": "f97f284037b04badb6bb7aacd9654a4e",
+                      "info": "Synse Temperature Sensor 5",
+                      "type": "temperature"
+                    },
+                    {
+                      "id": "eb9a56f95b5bd6d9b51996ccd0f2329c",
+                      "info": "Synse Fan",
+                      "type": "fan"
+                    },
+                    {
+                      "id": "f52d29fecf05a195af13f14c7306cfed",
+                      "info": "Synse LED",
+                      "type": "led"
+                    },
+                    {
+                      "id": "d29e0bd113a484dc48fd55bd3abad6bb",
+                      "info": "Synse Backup LED",
+                      "type": "led"
                     }
                   ]
                 }

--- a/synse/utils.py
+++ b/synse/utils.py
@@ -30,3 +30,20 @@ def composite(rack, board, device):
         str: A composite of the input strings.
     """
     return '-'.join([rack, board, device])
+
+
+def type_from_kind(kind):
+    """Get the device type from the device kind.
+
+    The device kind is the fully qualified name of the device kind, e.g.
+    'foo.bar.temperature'. The device type should be the last element of
+    the name-spaced kind, where the delimiter is a period.
+
+    Args:
+        kind (str): The device kind.
+
+    Returns:
+        str: The type of the devices, derived from the device kind.
+    """
+    components = kind.split('.')
+    return components[-1]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,3 +17,18 @@ def test_composite(params, expected):
     """Test successfully composing various string combinations."""
     actual = utils.composite(*params)
     assert expected == actual
+
+
+@pytest.mark.parametrize(
+    'kind,expected', [
+        ('foo', 'foo'),
+        ('foo.bar', 'bar'),
+        ('...temperature', 'temperature'),
+        ('device.1.2.3.4.5.6.humidity', 'humidity'),
+        ('', '')
+    ]
+)
+def test_type_from_kind(kind, expected):
+    """Test getting the device type from the device kind."""
+    actual = utils.type_from_kind(kind)
+    assert expected == actual


### PR DESCRIPTION
fixes a bug in the scan output found by @MatthewHink where the `type` field displayed the device kind, not the type.

added unit test, and did a test locally with a modified emulator -- you see that the scan reports the type as `temperature`, but the capabilities endpoint shows the full kind as `test.temperature`

```
edaniszewski ~/dev/vaporio/synse-server (scan-type-output *) ➜ curl localhost:5000/synse/2.1/scan
{
  "racks":[
    {
      "id":"rack-1",
      "boards":[
        {
          "id":"vec",
          "devices":[
            {
              "id":"34c226b1afadaae5f172a4e1763fd1a6",
              "info":"Synse Humidity Sensor",
              "type":"humidity"
            },
            {
              "id":"52d8a14a77478f9163f78c39e228a524",
              "info":"Synse Temperature Sensor 1",
              "type":"temperature"
            },
            {
              "id":"1565c28442f21c9e9e9a2bb542950edf",
              "info":"Synse Temperature Sensor 2",
              "type":"temperature"
            },
            {
              "id":"b5b86f361e76835879bd9d85f012e5d1",
              "info":"Synse Temperature Sensor 4",
              "type":"temperature"
            },
            {
              "id":"df6a06d6e28da8aab0c25ee41688fd1c",
              "info":"Synse Airflow Sensor",
              "type":"airflow"
            },
            {
              "id":"12835beffd3e6c603aa4dd92127707b5",
              "info":"Synse Fan",
              "type":"fan"
            },
            {
              "id":"12ea5644d052c6bf1bca3c9864fd8a44",
              "info":"Synse LED",
              "type":"led"
            },
            {
              "id":"bcf0618c50bff9121cb10d141d66f46f",
              "info":"Synse backup LED",
              "type":"led"
            },
            {
              "id":"e385de0e2b5d16af5e34167d479fc766",
              "info":"Synse Pressure Sensor 1",
              "type":"pressure"
            },
            {
              "id":"f838b2d6afceb01e7a2634893f6f935c",
              "info":"Synse Pressure Sensor 2",
              "type":"pressure"
            },
            {
              "id":"907c0f333db803271c837a37548a5331",
              "info":"Synse Temperature Sensor 3",
              "type":"temperature"
            },
            {
              "id":"92a8c6e1f4cfb206c38910965f545b03",
              "info":"Synse Temperature Sensor 5",
              "type":"temperature"
            }
          ]
        }
      ]
    }
  ]
}
edaniszewski ~/dev/vaporio/synse-server (scan-type-output *) ➜ curl localhost:5000/synse/2.1/capabilities
[
  {
    "plugin":"vaporio\/emulator-plugin",
    "devices":[
      {
        "kind":"fan",
        "outputs":[
          "fan.speed"
        ]
      },
      {
        "kind":"led",
        "outputs":[
          "led.state",
          "led.color"
        ]
      },
      {
        "kind":"pressure",
        "outputs":[
          "pressure"
        ]
      },
      {
        "kind":"test.temperature",
        "outputs":[
          "temperature"
        ]
      },
      {
        "kind":"airflow",
        "outputs":[
          "airflow"
        ]
      },
      {
        "kind":"humidity",
        "outputs":[
          "humidity",
          "temperature"
        ]
      }
    ]
  }
]
```