### PR TITLE
sort devices in scan by id

### DIFF
--- a/synse/__init__.py
+++ b/synse/__init__.py
@@ -3,7 +3,7 @@ and virtual devices.
 """
 
 __title__ = 'synse'
-__version__ = '2.2.1'
+__version__ = '2.2.2'
 __description__ = 'Synse Server'
 __author__ = 'Vapor IO'
 __author_email__ = 'vapor@vapor.io'

--- a/synse/cache.py
+++ b/synse/cache.py
@@ -609,7 +609,7 @@ def _build_scan_cache(device_info):
                 # Sort all devices on each board by plugin and sort ordinal
                 board['devices'] = sorted(
                     board['devices'],
-                    key=lambda d: (d['plugin'], d['sort_ordinal'])
+                    key=lambda d: (d['plugin'], d['sort_ordinal'], d['id'])
                 )
 
                 # Delete the plugin and sort_ordinal from the scan result after sorting.

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -476,12 +476,51 @@ def test_build_scan_cache_ok():
     device_info = {
         'rack-1-vec-12345': make_device_info_response('rack-1', 'vec', '12345'),
         'rack-1-board-12345': make_device_info_response('rack-1', 'board', '12345'),
-        'rack-1-board-56789': make_device_info_response('rack-1', 'board', '456789')
+        'rack-1-board-56789': make_device_info_response('rack-1', 'board', '456789'),
+        'rack-1-board-abcd': make_device_info_response('rack-1', 'board', 'abcd')
     }
     scan_cache = cache._build_scan_cache(device_info)
-    validate_scan_cache(scan_cache, 'rack-1', 'vec', '12345')
-    validate_scan_cache(scan_cache, 'rack-1', 'board', '12345')
-    validate_scan_cache(scan_cache, 'rack-1', 'board', '456789')
+
+    # Test that the scan cache comes back in the expected sorted order
+    assert scan_cache == {
+        'racks': [
+            {
+                'id': 'rack-1',
+                'boards': [
+                    {
+                        'id': 'board',
+                        'devices': [
+                            {
+                                'id': '12345',
+                                'info': 'bar',
+                                'type': 'thermistor'
+                            },
+                            {
+                                'id': '456789',
+                                'info': 'bar',
+                                'type': 'thermistor'
+                            },
+                            {
+                                'id': 'abcd',
+                                'info': 'bar',
+                                'type': 'thermistor'
+                            },
+                        ]
+                    },
+                    {
+                        'id': 'vec',
+                        'devices': [
+                            {
+                                'id': '12345',
+                                'info': 'bar',
+                                'type': 'thermistor'
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
 
 
 def test_build_scan_cache_no_device_info():


### PR DESCRIPTION
In the scan result, devices were not being sorted by id. This adds the device id as a key to sort against (after plugin/sort ordinal for the device). 

I'm not sure how this previously sorted devices by id without this in place.. 

Updated a unit test to check the sort order.