### PR TITLE
scope kubernetes discovery to a single namespace

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiocache==0.8.0
 aiofiles==0.3.2           # via sanic
-bison==0.0.6
+bison==0.1.0
 cachetools==2.1.0         # via google-auth
 certifi==2018.4.16        # via kubernetes, requests
 chardet==3.0.4            # via requests

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     python_requires='>=3.6',
     install_requires=[
         'aiocache',
-        'bison>=0.0.6',
+        'bison>=0.1.0',
         'grpcio',
         'kubernetes',
         'pyyaml',

--- a/synse/config.py
+++ b/synse/config.py
@@ -1,4 +1,5 @@
 """Synse Server configuration and scheme definition."""
+# pylint: disable=line-too-long
 
 from bison import Bison, DictOption, ListOption, Option, Scheme
 
@@ -12,6 +13,7 @@ scheme = Scheme(
         ListOption('unix', default=[], member_type=str, bind_env=True),
         DictOption('discover', required=False, bind_env=True, scheme=Scheme(
             DictOption('kubernetes', required=False, bind_env=True, scheme=Scheme(
+                Option('namespace', required=False, bind_env=True, field_type=str),
                 DictOption('endpoints', required=False, bind_env=True, scheme=Scheme(
                     DictOption('labels', bind_env=True, scheme=None)
                 )),

--- a/synse/discovery/kubernetes.py
+++ b/synse/discovery/kubernetes.py
@@ -33,6 +33,7 @@ def discover():
     ns = config.options.get('plugin.discover.kubernetes.namespace')
     if not ns:
         ns = 'default'
+    logger.debug(_('Using namespace "{}" for k8s discovery').format(ns))
 
     # Currently, we only support plugin discovery via kubernetes service
     # endpoints, under the `plugin.discover.kubernetes.endpoints` config

--- a/synse/discovery/kubernetes.py
+++ b/synse/discovery/kubernetes.py
@@ -22,29 +22,51 @@ def discover():
     if not cfg:
         return addresses
 
+    # Currently, everything we want to be able to discover (namely, endpoints)
+    # should all be in the same namespace, so we define it globally. If other
+    # methods of lookup are added later, we could also have a namespace per
+    # resource, e.g. so we can look for endpoints in namespace X and pods in
+    # namespace Y, etc.
+    #
+    # If no namespace is provided via user configuration, if will default to
+    # the 'default' namespace.
+    ns = config.options.get('plugin.discover.kubernetes.namespace')
+    if not ns:
+        ns = 'default'
+
     # Currently, we only support plugin discovery via kubernetes service
     # endpoints, under the `plugin.discover.kubernetes.endpoints` config
     # field.
     #
     # We can support other means later.
-    from_endpoints = _register_from_endpoints(cfg.get('endpoints'))
-    addresses.extend(from_endpoints)
+    endpoints_cfg = cfg.get('endpoints')
+    if endpoints_cfg:
+        addresses.extend(_register_from_endpoints(ns=ns, cfg=endpoints_cfg))
 
     return addresses
 
 
-def _register_from_endpoints(cfg):
+def _register_from_endpoints(ns, cfg):
     """Register plugins with Synse Server discovered via kubernetes
     service endpoints.
 
     Args:
-        cfg (dict): The configuration for service discovery via kubernetes
-            endpoints.
+        ns (str): The namespace to get the endpoints from.
+        cfg (dict): The configuration for service discovery via
+            kubernetes endpoints.
 
     Returns:
         list[str]: A list of host:port addresses for the plugin endpoints
             that matched the config.
+
+    Raises:
+        ValueError: The given namespace is empty.
     """
+    if not ns:
+        raise ValueError(
+            'A namespace must be provided for discovery via k8s service endpoints.'
+        )
+
     found = []
 
     # Gather the filters/options needed to find the endpoints we are interested
@@ -69,7 +91,7 @@ def _register_from_endpoints(cfg):
     kubernetes.config.load_incluster_config()
     v1 = kubernetes.client.CoreV1Api()
 
-    endpoints = v1.list_endpoints_for_all_namespaces(label_selector=label_selector)
+    endpoints = v1.list_namespaced_endpoints(namespace=ns, label_selector=label_selector)
 
     # Now we parse out the endpoints to get the routing info to a plugin.
     # There are some assumptions here:

--- a/synse/discovery/kubernetes.py
+++ b/synse/discovery/kubernetes.py
@@ -30,9 +30,7 @@ def discover():
     #
     # If no namespace is provided via user configuration, if will default to
     # the 'default' namespace.
-    ns = config.options.get('plugin.discover.kubernetes.namespace')
-    if not ns:
-        ns = 'default'
+    ns = config.options.get('plugin.discover.kubernetes.namespace', 'default')
     logger.debug(_('Using namespace "{}" for k8s discovery').format(ns))
 
     # Currently, we only support plugin discovery via kubernetes service

--- a/synse/locale/en_US/LC_MESSAGES/synse.po
+++ b/synse/locale/en_US/LC_MESSAGES/synse.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Synse Server VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-10-24 11:18-0400\n"
+"POT-Creation-Date: 2018-10-26 09:17-0400\n"
 "PO-Revision-Date: 2018-04-23 14:33-0400\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en_US\n"
@@ -317,47 +317,51 @@ msgstr ""
 msgid "Failed to add transaction {} to the cache"
 msgstr ""
 
-#: synse/discovery/kubernetes.py:55
+#: synse/discovery/kubernetes.py:36
+msgid "Using namespace \"{}\" for k8s discovery"
+msgstr ""
+
+#: synse/discovery/kubernetes.py:78
 msgid "No labels found for kubernetes service discovery via endpoints"
 msgstr ""
 
-#: synse/discovery/kubernetes.py:65
+#: synse/discovery/kubernetes.py:88
 msgid "Using endpoint label selector: {}"
 msgstr ""
 
-#: synse/discovery/kubernetes.py:79
+#: synse/discovery/kubernetes.py:102
 msgid "Found endpoint with name: {}"
 msgstr ""
 
-#: synse/discovery/kubernetes.py:87
+#: synse/discovery/kubernetes.py:110
 msgid "No addresses for subset of endpoint - skipping ({})"
 msgstr ""
 
-#: synse/discovery/kubernetes.py:96
+#: synse/discovery/kubernetes.py:119
 msgid "Address has no target_ref - skipping ({})"
 msgstr ""
 
-#: synse/discovery/kubernetes.py:101
+#: synse/discovery/kubernetes.py:124
 msgid "Address is not a pod address - skipping ({})"
 msgstr ""
 
-#: synse/discovery/kubernetes.py:109
+#: synse/discovery/kubernetes.py:132
 msgid "No ips found for endpoint, will not search for port"
 msgstr ""
 
-#: synse/discovery/kubernetes.py:116
+#: synse/discovery/kubernetes.py:139
 msgid "No ports for subset of endpoint - skipping ({})"
 msgstr ""
 
-#: synse/discovery/kubernetes.py:126
+#: synse/discovery/kubernetes.py:149
 msgid "skipping port (want name:http, but found name:{})"
 msgstr ""
 
-#: synse/discovery/kubernetes.py:138
+#: synse/discovery/kubernetes.py:161
 msgid "found plugin: endpoint.name={}, ip={}, port={}"
 msgstr ""
 
-#: synse/discovery/kubernetes.py:145
+#: synse/discovery/kubernetes.py:168
 msgid "Did not find any plugins via kubernetes endpoints (labels={})"
 msgstr ""
 

--- a/tests/unit/discovery/test_kubernetes.py
+++ b/tests/unit/discovery/test_kubernetes.py
@@ -2,6 +2,7 @@
 # pylint: disable=unused-argument,missing-docstring
 
 import kubernetes
+import pytest
 
 from synse import config
 from synse.discovery import kubernetes as k8s
@@ -22,10 +23,20 @@ def test_discovery_empty_endpoints():
     assert res == []
 
 
+def test_register_from_endpoints_no_ns():
+    """An empty namespace string is provided to the _register_from_endpoints function."""
+
+    with pytest.raises(ValueError):
+        k8s._register_from_endpoints('', {})
+
+
 def test_register_from_endpoints_empty_cfg():
     """Pass an empty config to _register_from_endpoints."""
 
-    res = k8s._register_from_endpoints({})
+    res = k8s._register_from_endpoints(
+        ns='default',
+        cfg={}
+    )
     assert res == []
 
 
@@ -35,16 +46,17 @@ def test_no_endpoints():
     # mock out the 'load incluster config' fn so it does nothing
     k8s.kubernetes.config.load_incluster_config = lambda: None
 
-    # mock out the CoreV1Api object's list_endpoints_for_all_namespaces
+    # mock out the CoreV1Api object's list_namespaced_endpoints
     # to return no endpoints.
     class MockCoreV1Api:
-        def list_endpoints_for_all_namespaces(self, *args, **kwargs):
+        def list_namespaced_endpoints(self, *args, **kwargs):
             return kubernetes.client.V1EndpointsList(items=[])
     k8s.kubernetes.client.CoreV1Api = MockCoreV1Api
 
-    res = k8s._register_from_endpoints({
-        'labels': {'foo': 'bar'}
-    })
+    res = k8s._register_from_endpoints(
+        ns='default',
+        cfg={'labels': {'foo': 'bar'}}
+    )
     assert res == []
 
 
@@ -54,10 +66,10 @@ def test_one_endpoint_no_subsets():
     # mock out the 'load incluster config' fn so it does nothing
     k8s.kubernetes.config.load_incluster_config = lambda: None
 
-    # mock out the CoreV1Api object's list_endpoints_for_all_namespaces
+    # mock out the CoreV1Api object's list_namespaced_endpoints
     # to return no endpoints.
     class MockCoreV1Api:
-        def list_endpoints_for_all_namespaces(self, *args, **kwargs):
+        def list_namespaced_endpoints(self, *args, **kwargs):
             return kubernetes.client.V1EndpointsList(items=[
                 kubernetes.client.V1Endpoints(
                     metadata=kubernetes.client.V1ObjectMeta(
@@ -69,9 +81,10 @@ def test_one_endpoint_no_subsets():
 
     k8s.kubernetes.client.CoreV1Api = MockCoreV1Api
 
-    res = k8s._register_from_endpoints({
-        'labels': {'foo': 'bar'}
-    })
+    res = k8s._register_from_endpoints(
+        ns='default',
+        cfg={'labels': {'foo': 'bar'}}
+    )
     assert res == []
 
 
@@ -81,10 +94,10 @@ def test_one_endpoint_no_addresses():
     # mock out the 'load incluster config' fn so it does nothing
     k8s.kubernetes.config.load_incluster_config = lambda: None
 
-    # mock out the CoreV1Api object's list_endpoints_for_all_namespaces
+    # mock out the CoreV1Api object's list_namespaced_endpoints
     # to return no endpoints.
     class MockCoreV1Api:
-        def list_endpoints_for_all_namespaces(self, *args, **kwargs):
+        def list_namespaced_endpoints(self, *args, **kwargs):
             return kubernetes.client.V1EndpointsList(items=[
                 kubernetes.client.V1Endpoints(
                     metadata=kubernetes.client.V1ObjectMeta(
@@ -107,9 +120,10 @@ def test_one_endpoint_no_addresses():
 
     k8s.kubernetes.client.CoreV1Api = MockCoreV1Api
 
-    res = k8s._register_from_endpoints({
-        'labels': {'foo': 'bar'}
-    })
+    res = k8s._register_from_endpoints(
+        ns='default',
+        cfg={'labels': {'foo': 'bar'}}
+    )
     assert res == []
 
 
@@ -119,10 +133,10 @@ def test_one_endpoint_no_ports():
     # mock out the 'load incluster config' fn so it does nothing
     k8s.kubernetes.config.load_incluster_config = lambda: None
 
-    # mock out the CoreV1Api object's list_endpoints_for_all_namespaces
+    # mock out the CoreV1Api object's list_namespaced_endpoints
     # to return no endpoints.
     class MockCoreV1Api:
-        def list_endpoints_for_all_namespaces(self, *args, **kwargs):
+        def list_namespaced_endpoints(self, *args, **kwargs):
             return kubernetes.client.V1EndpointsList(items=[
                 kubernetes.client.V1Endpoints(
                     metadata=kubernetes.client.V1ObjectMeta(
@@ -150,9 +164,10 @@ def test_one_endpoint_no_ports():
 
     k8s.kubernetes.client.CoreV1Api = MockCoreV1Api
 
-    res = k8s._register_from_endpoints({
-        'labels': {'foo': 'bar'}
-    })
+    res = k8s._register_from_endpoints(
+        ns='default',
+        cfg={'labels': {'foo': 'bar'}}
+    )
     assert res == []
 
 
@@ -162,10 +177,10 @@ def test_endpoint_no_addr_match():
     # mock out the 'load incluster config' fn so it does nothing
     k8s.kubernetes.config.load_incluster_config = lambda: None
 
-    # mock out the CoreV1Api object's list_endpoints_for_all_namespaces
+    # mock out the CoreV1Api object's list_namespaced_endpoints
     # to return no endpoints.
     class MockCoreV1Api:
-        def list_endpoints_for_all_namespaces(self, *args, **kwargs):
+        def list_namespaced_endpoints(self, *args, **kwargs):
             return kubernetes.client.V1EndpointsList(items=[
                 kubernetes.client.V1Endpoints(
                     metadata=kubernetes.client.V1ObjectMeta(
@@ -199,9 +214,10 @@ def test_endpoint_no_addr_match():
 
     k8s.kubernetes.client.CoreV1Api = MockCoreV1Api
 
-    res = k8s._register_from_endpoints({
-        'labels': {'foo': 'bar'}
-    })
+    res = k8s._register_from_endpoints(
+        ns='default',
+        cfg={'labels': {'foo': 'bar'}}
+    )
     assert res == []
 
 
@@ -211,10 +227,10 @@ def test_one_endpoint():
     # mock out the 'load incluster config' fn so it does nothing
     k8s.kubernetes.config.load_incluster_config = lambda: None
 
-    # mock out the CoreV1Api object's list_endpoints_for_all_namespaces
+    # mock out the CoreV1Api object's list_namespaced_endpoints
     # to return no endpoints.
     class MockCoreV1Api:
-        def list_endpoints_for_all_namespaces(self, *args, **kwargs):
+        def list_namespaced_endpoints(self, *args, **kwargs):
             return kubernetes.client.V1EndpointsList(items=[
                 kubernetes.client.V1Endpoints(
                     metadata=kubernetes.client.V1ObjectMeta(
@@ -248,9 +264,10 @@ def test_one_endpoint():
 
     k8s.kubernetes.client.CoreV1Api = MockCoreV1Api
 
-    res = k8s._register_from_endpoints({
-        'labels': {'foo': 'bar'}
-    })
+    res = k8s._register_from_endpoints(
+        ns='default',
+        cfg={'labels': {'foo': 'bar'}}
+    )
     assert res == ['127.0.0.1:7766']
 
 
@@ -260,10 +277,10 @@ def test_one_endpoint_multiple_ports_ok():
     # mock out the 'load incluster config' fn so it does nothing
     k8s.kubernetes.config.load_incluster_config = lambda: None
 
-    # mock out the CoreV1Api object's list_endpoints_for_all_namespaces
+    # mock out the CoreV1Api object's list_namespaced_endpoints
     # to return no endpoints.
     class MockCoreV1Api:
-        def list_endpoints_for_all_namespaces(self, *args, **kwargs):
+        def list_namespaced_endpoints(self, *args, **kwargs):
             return kubernetes.client.V1EndpointsList(items=[
                 kubernetes.client.V1Endpoints(
                     metadata=kubernetes.client.V1ObjectMeta(
@@ -302,9 +319,10 @@ def test_one_endpoint_multiple_ports_ok():
 
     k8s.kubernetes.client.CoreV1Api = MockCoreV1Api
 
-    res = k8s._register_from_endpoints({
-        'labels': {'foo': 'bar'}
-    })
+    res = k8s._register_from_endpoints(
+        ns='default',
+        cfg={'labels': {'foo': 'bar'}}
+    )
     assert res == ['127.0.0.1:7788']
 
 
@@ -314,10 +332,10 @@ def test_one_endpoint_multiple_ports_invalid():
     # mock out the 'load incluster config' fn so it does nothing
     k8s.kubernetes.config.load_incluster_config = lambda: None
 
-    # mock out the CoreV1Api object's list_endpoints_for_all_namespaces
+    # mock out the CoreV1Api object's list_namespaced_endpoints
     # to return no endpoints.
     class MockCoreV1Api:
-        def list_endpoints_for_all_namespaces(self, *args, **kwargs):
+        def list_namespaced_endpoints(self, *args, **kwargs):
             return kubernetes.client.V1EndpointsList(items=[
                 kubernetes.client.V1Endpoints(
                     metadata=kubernetes.client.V1ObjectMeta(
@@ -356,9 +374,10 @@ def test_one_endpoint_multiple_ports_invalid():
 
     k8s.kubernetes.client.CoreV1Api = MockCoreV1Api
 
-    res = k8s._register_from_endpoints({
-        'labels': {'foo': 'bar'}
-    })
+    res = k8s._register_from_endpoints(
+        ns='default',
+        cfg={'labels': {'foo': 'bar'}}
+    )
     assert res == []
 
 
@@ -370,10 +389,10 @@ def test_one_endpoint_multiple_addrs():
     # mock out the 'load incluster config' fn so it does nothing
     k8s.kubernetes.config.load_incluster_config = lambda: None
 
-    # mock out the CoreV1Api object's list_endpoints_for_all_namespaces
+    # mock out the CoreV1Api object's list_namespaced_endpoints
     # to return no endpoints.
     class MockCoreV1Api:
-        def list_endpoints_for_all_namespaces(self, *args, **kwargs):
+        def list_namespaced_endpoints(self, *args, **kwargs):
             return kubernetes.client.V1EndpointsList(items=[
                 kubernetes.client.V1Endpoints(
                     metadata=kubernetes.client.V1ObjectMeta(
@@ -436,9 +455,10 @@ def test_one_endpoint_multiple_addrs():
 
     k8s.kubernetes.client.CoreV1Api = MockCoreV1Api
 
-    res = k8s._register_from_endpoints({
-        'labels': {'foo': 'bar'}
-    })
+    res = k8s._register_from_endpoints(
+        ns='default',
+        cfg={'labels': {'foo': 'bar'}}
+    )
     assert res == ['127.0.0.1:7766', '127.0.0.4:7766']
 
 
@@ -448,10 +468,10 @@ def test_one_endpoint_multiple_subsets():
     # mock out the 'load incluster config' fn so it does nothing
     k8s.kubernetes.config.load_incluster_config = lambda: None
 
-    # mock out the CoreV1Api object's list_endpoints_for_all_namespaces
+    # mock out the CoreV1Api object's list_namespaced_endpoints
     # to return no endpoints.
     class MockCoreV1Api:
-        def list_endpoints_for_all_namespaces(self, *args, **kwargs):
+        def list_namespaced_endpoints(self, *args, **kwargs):
             return kubernetes.client.V1EndpointsList(items=[
                 kubernetes.client.V1Endpoints(
                     metadata=kubernetes.client.V1ObjectMeta(
@@ -506,9 +526,10 @@ def test_one_endpoint_multiple_subsets():
 
     k8s.kubernetes.client.CoreV1Api = MockCoreV1Api
 
-    res = k8s._register_from_endpoints({
-        'labels': {'foo': 'bar'}
-    })
+    res = k8s._register_from_endpoints(
+        ns='default',
+        cfg={'labels': {'foo': 'bar'}}
+    )
     assert res == ['127.0.0.1:7766', '129.0.0.1:7799']
 
 
@@ -518,10 +539,10 @@ def test_multiple_endpoints():
     # mock out the 'load incluster config' fn so it does nothing
     k8s.kubernetes.config.load_incluster_config = lambda: None
 
-    # mock out the CoreV1Api object's list_endpoints_for_all_namespaces
+    # mock out the CoreV1Api object's list_namespaced_endpoints
     # to return no endpoints.
     class MockCoreV1Api:
-        def list_endpoints_for_all_namespaces(self, *args, **kwargs):
+        def list_namespaced_endpoints(self, *args, **kwargs):
             return kubernetes.client.V1EndpointsList(items=[
                 kubernetes.client.V1Endpoints(
                     metadata=kubernetes.client.V1ObjectMeta(
@@ -583,7 +604,8 @@ def test_multiple_endpoints():
 
     k8s.kubernetes.client.CoreV1Api = MockCoreV1Api
 
-    res = k8s._register_from_endpoints({
-        'labels': {'foo': 'bar'}
-    })
+    res = k8s._register_from_endpoints(
+        ns='default',
+        cfg={'labels': {'foo': 'bar'}}
+    )
     assert res == ['127.0.0.1:7766', '128.0.0.1:7755']

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,32 @@
+"""Test the 'synse.config' Synse Server module."""
+
+from synse.config import options
+
+
+def test_defaults():
+    """Check that the config defaults are set properly."""
+
+    # parse and validate so the defaults are loaded
+    options.parse(requires_cfg=False)
+    options.validate()
+
+    assert options.config == {
+        'logging': 'info',
+        'pretty_json': True,
+        'locale': 'en_US',
+        'plugin': {
+            'tcp': [],
+            'unix': [],
+        },
+        'cache': {
+            'meta': {
+                'ttl': 20
+            },
+            'transaction': {
+                'ttl': 300
+            }
+        },
+        'grpc': {
+            'timeout': 3
+        },
+    }


### PR DESCRIPTION
fixes #222 

This also adds in a basic test case for the config to make sure that no kubernetes config values get set by default. We only want discovery to happen if its set explicitly. 

tested this on a gke cluster w/ synse-server and emulator plugin.