### PR TITLE
patch: update requests dep for CVE-2018-18074

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pyasn1==0.4.3             # via pyasn1-modules, rsa
 python-dateutil==2.7.3    # via kubernetes
 pyyaml==3.12
 requests-oauthlib==1.0.0  # via kubernetes
-requests==2.19.1          # via kubernetes, requests-oauthlib
+requests==2.20.0
 rsa==3.4.2                # via google-auth
 sanic==0.8.3
 six==1.11.0               # via google-auth, grpcio, kubernetes, protobuf, python-dateutil, websocket-client

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'grpcio',
         'kubernetes',
         'pyyaml',
+        'requests>=2.20.0',
         'sanic>=0.8.0',
         'synse-grpc>=1.1.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'grpcio',
         'kubernetes',
         'pyyaml',
-        'requests>=2.20.0',
+        'requests>=2.20.0',  # used by 'kubernetes'
         'sanic>=0.8.0',
         'synse-grpc>=1.1.0',
     ],

--- a/synse/__init__.py
+++ b/synse/__init__.py
@@ -3,7 +3,7 @@ and virtual devices.
 """
 
 __title__ = 'synse'
-__version__ = '2.2.3'
+__version__ = '2.2.4'
 __description__ = 'Synse Server'
 __author__ = 'Vapor IO'
 __author_email__ = 'vapor@vapor.io'


### PR DESCRIPTION
This PR updates the version of `requests` to 2.20.0 to patch the [CVE-2018-18074](https://nvd.nist.gov/vuln/detail/CVE-2018-18074) vulnerability found in `requests<=2.19.1`.

Bumps the version to 2.2.4 for patch release.