### PR TITLE
Update temporary directory usage in tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,6 +44,7 @@ results
 .jenkins
 .coverage
 .pytest_cache
+tests/testdata
 
 # Logs
 logs/

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ results/
 prof/
 *.log
 .pytest_cache/
+tests/testdata/*
+!tests/testdata/README.md
 
 # Flask stuff:
 instance/

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,1 @@
 """Tests for Synse Server"""
-
-import os
-
-# directory where test data is created and stored for tests.
-# it is created at the beginning of test runs and cleaned up
-# at the end of test runs.
-data_dir = os.path.expanduser('~/_tmp_test')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,58 +2,35 @@
 
 import logging
 import os
-import shutil
 
 import pytest
 import yaml
 
 from synse import config, const, factory
-from tests import data_dir
 
 _app = None
 
 
-@pytest.fixture(scope='session')
-def app():
+@pytest.fixture()
+def app(tmpdir):
     """Fixture to get a Synse Server application instance."""
     global _app
+
+    appdir = tmpdir.mkdir('appdata')
 
     # override the default config directory location for testing. this is
     # to prevent collision with anything in the local default socket directory,
     # which could be the case if you are running plugins locally directly
     # on the host (e.g. for development)
-    const.SOCKET_DIR = os.path.join(data_dir, 'socks')
+    const.SOCKET_DIR = os.path.join(appdir, 'socks')
 
     # if the app doesn't exist, create it
     if _app is None:
-        with open(os.path.join(data_dir, 'config.yml'), 'w') as f:
+        with open(os.path.join(appdir, 'config.yml'), 'w') as f:
             yaml.dump({'log': 'debug'}, f)
-        config.options.add_config_paths(data_dir)
+        config.options.add_config_paths(appdir)
         _app = factory.make_app()
     return _app
-
-
-@pytest.fixture(scope='module', autouse=True)
-def tmp_dir():
-    """Fixture to create and remove the _tmp dir, used to hold test data."""
-    if not os.path.isdir(data_dir):
-        os.mkdir(data_dir)
-
-    yield
-    if os.path.isdir(data_dir):
-        shutil.rmtree(data_dir)
-
-
-@pytest.fixture(autouse=True)
-def clear_tmp_dir():
-    """Clear the _tmp directory of test data between tests."""
-    yield
-    for f in os.listdir(data_dir):
-        path = os.path.join(data_dir, f)
-        if os.path.isdir(path):
-            shutil.rmtree(path)
-        else:
-            os.unlink(path)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 
 import logging
 import os
+import shutil
+import socket
 
 import pytest
 import yaml
@@ -9,6 +11,31 @@ import yaml
 from synse import config, const, factory
 
 _app = None
+
+
+class SocketManager:
+    """SocketManager is a helper class for creating, managing, and destroying
+    temporary sockets for testing.
+    """
+
+    def __init__(self, base_path):
+        self.base_path = base_path
+        self.socket_dir = os.path.join(self.base_path, 'socks')
+
+        self._old_socket_path = const.SOCKET_DIR
+        os.mkdir(self.socket_dir)
+        const.SOCKET_DIR = self.socket_dir
+
+    def __del__(self):
+        const.SOCKET_DIR = self._old_socket_path
+        shutil.rmtree(self.socket_dir)
+
+    def add(self, name):
+        """Create a new socket in the socket path."""
+        path = os.path.join(self.socket_dir, name)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.bind(path)
+        return sock, path
 
 
 @pytest.fixture()
@@ -31,6 +58,20 @@ def app(tmpdir):
         config.options.add_config_paths(appdir)
         _app = factory.make_app()
     return _app
+
+
+@pytest.fixture()
+def tmpsocket():
+    """Fixture that can be used to generate and manage test unix socket data.
+
+    This should be used for all tests that need to set up a unix socket for
+    plugin testing. Pytest's tmpdir fixture generally will create temporary
+    directories with long path names, but socket paths are character bound,
+    so that can lead to test errors.
+
+    The socket test data here is all stored in the `tests/testdata` directory.
+    """
+    yield SocketManager('tests/testdata')
 
 
 @pytest.fixture(autouse=True)

--- a/tests/testdata/README.md
+++ b/tests/testdata/README.md
@@ -1,0 +1,12 @@
+This directory is used to house runtime-generated test data pertaining to testing
+with unix sockets. Unix socket paths have a character limitation which the builtin
+pytest [`tmpdir`](https://docs.pytest.org/en/2.8.7/tmpdir.html) fixture will often
+exceed because of how it generates unique numbered directories for each test case, e.g.
+
+```
+tmpdir = local('/var/lib/jenkins/workspace/-server_update-test-dir-fixtures/tests/testdata/test_register_unix_plugin_no_c0')
+```
+
+For testing purposes, socket generation should be done via the `tmpsocket` fixture,
+defined in `conftest.py`. Tests which require a temporary directory but do not use
+sockets should use pytests' `tmpdir` fixture.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,7 +6,6 @@ import bison
 import pytest
 
 from synse import cache, config, const, plugin
-from tests import data_dir
 
 
 @pytest.fixture(autouse=True)
@@ -14,7 +13,7 @@ def reset_state():
     """Fixture to reset all Synse Server state between tests."""
 
     _old = const.SOCKET_DIR
-    const.SOCKET_DIR = data_dir
+    #const.SOCKET_DIR = data_dir
 
     yield
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,8 +1,6 @@
 """Test the 'synse.cache' Synse Server module."""
 # pylint: disable=redefined-outer-name,unused-argument,line-too-long
 
-import os
-
 import aiocache
 import asynctest
 import grpc
@@ -11,7 +9,6 @@ from synse_grpc import api
 
 from synse import cache, errors, plugin
 from synse.proto import client
-from tests import data_dir
 
 # -- Helper Methods ---
 
@@ -82,12 +79,13 @@ def patch_device_info(monkeypatch):
 
 
 @pytest.fixture()
-def plugin_context():
+def plugin_context(tmpdir):
     """Fixture to setup and teardown the test context for creating plugins."""
 
     # create dummy 'socket' files for the plugins
-    open(os.path.join(data_dir, 'foo'), 'w').close()
-    open(os.path.join(data_dir, 'bar'), 'w').close()
+    sockdir = tmpdir.mkdir('socks')
+    sockdir.join('foo')
+    sockdir.join('bar')
 
 
 # --- Test Cases ---

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -8,21 +8,23 @@ import ujson
 import yaml
 
 from synse import config, errors, factory
-from tests import data_dir
 
 
 @pytest.fixture()
-def make_config():
+def make_config(tmpdir):
     """Fixture to make a simple config file in the datadir"""
-    # this file gets cleaned out via a fixture in conftest.py
-    with open(os.path.join(data_dir, 'config.yml'), 'w') as f:
+    datadir = tmpdir.mkdir('appconfig')
+
+    with open(os.path.join(datadir, 'config.yml'), 'w') as f:
         yaml.dump({'log': 'debug'}, f)
+
+    return datadir
 
 
 def test_make_app(make_config):
     """Create a new instance of the Synse Server app."""
     config.options.set('locale', 'en_US')
-    config.options.add_config_paths(data_dir)
+    config.options.add_config_paths(make_config)
     app = factory.make_app()
 
     # check that the app we create has the expected blueprints registered

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -2,7 +2,6 @@
 # pylint: disable=redefined-outer-name,unused-argument,line-too-long
 
 import os
-import socket
 
 import pytest
 from synse_grpc import api
@@ -151,11 +150,9 @@ def test_plugin_path_not_exist():
     assert p.name == 'test'
 
 
-def test_plugin_unix_ok(tmpdir):
+def test_plugin_unix_ok(tmpsocket):
     """Create a UNIX plugin successfully"""
-    sockdir = tmpdir.mkdir('socks')
-    path = str(sockdir.join('test'))
-    const.SOCKET_DIR = str(sockdir)
+    _, path = tmpsocket.add('test')
 
     p = plugin.Plugin(
         metadata=api.Metadata(
@@ -249,15 +246,11 @@ def test_register_plugins_no_socks(tmpdir, grpc_timeout):
     assert len(plugin.Plugin.manager.plugins) == 0
 
 
-def test_register_plugins_ok(tmpdir, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
+def test_register_plugins_ok(tmpsocket, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
     """Register plugins successfully."""
-    sockdir = tmpdir.mkdir('socks')
-    path = str(sockdir.join('test'))
-    const.SOCKET_DIR = str(sockdir)
 
     # create the socket
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.bind(path)
+    _, path = tmpsocket.add('test')
 
     assert len(plugin.Plugin.manager.plugins) == 0
 
@@ -279,15 +272,11 @@ def test_register_plugins_ok(tmpdir, grpc_timeout, mock_client_test_ok, mock_cli
     assert p.protocol == 'unix'
 
 
-def test_register_plugins_already_exists(tmpdir, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
+def test_register_plugins_already_exists(tmpsocket, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
     """Register plugins when the plugins were already registered."""
-    sockdir = tmpdir.mkdir('socks')
-    path = str(sockdir.join('test'))
-    const.SOCKET_DIR = str(sockdir)
 
     # create the socket
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.bind(path)
+    _, path = tmpsocket.add('test')
 
     assert len(plugin.Plugin.manager.plugins) == 0
 
@@ -315,15 +304,11 @@ def test_register_plugins_already_exists(tmpdir, grpc_timeout, mock_client_test_
     assert p.protocol == 'unix'
 
 
-def test_register_plugins_new(tmpdir, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
+def test_register_plugins_new(tmpsocket, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
     """Re-register, adding a new plugin."""
-    sockdir = tmpdir.mkdir('socks')
-    path1 = str(sockdir.join('foo'))
-    const.SOCKET_DIR = str(sockdir)
 
     # create the socket
-    sock1 = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock1.bind(path1)
+    _, path1 = tmpsocket.add('foo')
 
     assert len(plugin.Plugin.manager.plugins) == 0
 
@@ -338,9 +323,7 @@ def test_register_plugins_new(tmpdir, grpc_timeout, mock_client_test_ok, mock_cl
     assert p.protocol == 'unix'
 
     # now, re-register
-    path2 = str(sockdir.join('bar'))
-    sock2 = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock2.bind(path2)
+    _, path2 = tmpsocket.add('bar')
 
     assert len(plugin.Plugin.manager.plugins) == 1
 
@@ -361,19 +344,12 @@ def test_register_plugins_new(tmpdir, grpc_timeout, mock_client_test_ok, mock_cl
     assert p.protocol == 'unix'
 
 
-def test_register_plugins_old(tmpdir, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
+def test_register_plugins_old(tmpsocket, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
     """Re-register, removing an old plugin."""
-    sockdir = tmpdir.mkdir('socks')
-    path1 = str(sockdir.join('foo'))
-    path2 = str(sockdir.join('bar'))
-    const.SOCKET_DIR = str(sockdir)
 
     # create the socket
-    sock1 = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock1.bind(path1)
-
-    sock2 = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock2.bind(path2)
+    _, path1 = tmpsocket.add('foo')
+    _, path2 = tmpsocket.add('bar')
 
     assert len(plugin.Plugin.manager.plugins) == 0
 
@@ -447,15 +423,11 @@ def test_register_unix_plugin_none_defined(grpc_timeout):
     assert len(registered) == 0
 
 
-def test_register_unix_plugin(tmpdir, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
+def test_register_unix_plugin(tmpsocket, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
     """Test registering unix plugin when a configuration is specified"""
-    sockdir = tmpdir.mkdir('socks')
-    path = str(sockdir.join('foo'))
-    const.SOCKET_DIR = str(sockdir)
 
     # create the socket
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.bind(path)
+    _, path = tmpsocket.add('foo')
 
     assert len(plugin.Plugin.manager.plugins) == 0
 
@@ -477,19 +449,12 @@ def test_register_unix_plugin(tmpdir, grpc_timeout, mock_client_test_ok, mock_cl
     assert p.address == path
 
 
-def test_register_unix_plugins(tmpdir, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
+def test_register_unix_plugins(tmpsocket, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
     """Test registering unix plugins when multiple configurations are specified"""
-    sockdir = tmpdir.mkdir('socks')
-    path1 = str(sockdir.join('foo'))
-    path2 = str(sockdir.join('bar'))
-    const.SOCKET_DIR = str(sockdir)
 
-    # create sockets
-    sock1 = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock1.bind(path1)
-
-    sock2 = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock2.bind(path2)
+    # create the socket
+    _, path1 = tmpsocket.add('foo')
+    _, path2 = tmpsocket.add('bar')
 
     assert len(plugin.Plugin.manager.plugins) == 0
 
@@ -518,15 +483,11 @@ def test_register_unix_plugins(tmpdir, grpc_timeout, mock_client_test_ok, mock_c
     assert p2.address == path2
 
 
-def test_register_unix_plugin_already_exists(tmpdir, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
+def test_register_unix_plugin_already_exists(tmpsocket, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
     """Test registering unix plugin when the plugin was already registered."""
-    sockdir = tmpdir.mkdir('socks')
-    path = str(sockdir.join('test'))
-    const.SOCKET_DIR = str(sockdir)
 
     # create the socket
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.bind(path)
+    _, path = tmpsocket.add('test')
 
     assert len(plugin.Plugin.manager.plugins) == 0
 
@@ -548,7 +509,7 @@ def test_register_unix_plugin_already_exists(tmpdir, grpc_timeout, mock_client_t
     assert len(plugin.Plugin.manager.plugins) == 1
 
     # set the same configuration
-    config.options.set('plugin.unix', [str(sockdir)])
+    config.options.set('plugin.unix', [str(tmpsocket.socket_dir)])
 
     registered = plugin.register_unix()
 
@@ -594,15 +555,11 @@ def test_register_unix_plugin_no_socket_no_path(grpc_timeout):
     assert len(registered) == 0
 
 
-def test_register_unix_plugin_no_config_path(tmpdir, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
+def test_register_unix_plugin_no_config_path(tmpsocket, grpc_timeout, mock_client_test_ok, mock_client_meta_ok):
     """Test registering unix plugin when a configuration without a path is specified"""
-    sockdir = tmpdir.mkdir('socks')
-    path = str(sockdir.join('foo'))
-    const.SOCKET_DIR = str(sockdir)
 
     # create the socket
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.bind(path)
+    _, path = tmpsocket.add('foo')
 
     assert len(plugin.Plugin.manager.plugins) == 0
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ passenv=
     SYNSE_TEST_HOST
 commands=
     pytest -s \
-        --basetemp=tests/testdata \
         --junitxml=results/pytest/junit.xml \
         --cov-report html:results/cov-html \
         --cov-report term \

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ passenv=
     SYNSE_TEST_HOST
 commands=
     pytest -s \
+        --basetemp=tests/testdata \
         --junitxml=results/pytest/junit.xml \
         --cov-report html:results/cov-html \
         --cov-report term \


### PR DESCRIPTION
Instead of using the custom temporary directory fixtures set up long ago, this updates tests to use pytest's `tmpdir`. Since socket names have a character limit (I think something like 100 chars), and `tmpdir` tends to make long/nested directories (good for isolation, bad for this use case), a `tmpsocket` fixture was created to manage sockets for tests.