### PR TITLE
Update dependencies for CVE-2019-11324

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,13 +24,13 @@ pyasn1==0.4.3             # via pyasn1-modules, rsa
 python-dateutil==2.7.3    # via kubernetes
 pyyaml==4.2b4
 requests-oauthlib==1.0.0  # via kubernetes
-requests==2.20.0
+requests==2.21.0
 rsa==3.4.2                # via google-auth
 sanic==0.8.3
 six==1.11.0               # via google-auth, grpcio, kubernetes, protobuf, python-dateutil, websocket-client
 synse-grpc==1.1.0
 ujson==1.35               # via sanic
-urllib3==1.23             # via kubernetes, requests
+urllib3==1.24.2
 uvloop==0.9.1             # via sanic
 websocket-client==0.48.0  # via kubernetes
 websockets==5.0.1         # via sanic

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
         'grpcio',
         'kubernetes',
         'pyyaml>=4.2b1',
-        'requests>=2.20.0',  # used by 'kubernetes'
+        'requests>=2.21.0',  # used by 'kubernetes'
+        'urllib3>=1.24.2',
         'sanic>=0.8.0',
         'synse-grpc>=1.1.0',
     ],


### PR DESCRIPTION
* updates the `requests` lib, which uses `urllib3`, to bump `urllib3` to `>=1.24.2` (see: [CVE-2019-11324](https://nvd.nist.gov/vuln/detail/CVE-2019-11324))