### PR TITLE
update config for synse v3

### DIFF
--- a/synse_server/cache.py
+++ b/synse_server/cache.py
@@ -24,7 +24,6 @@ transaction_cache = aiocache.SimpleMemoryCache(
 )
 
 device_cache = aiocache.SimpleMemoryCache(
-    ttl=config.options.get('cache.device.ttl', None),
     namespace=NS_DEVICE,
 )
 

--- a/synse_server/config.py
+++ b/synse_server/config.py
@@ -20,8 +20,8 @@ scheme = Scheme(
         )),
     )),
     DictOption('cache', default=None, scheme=Scheme(
-        DictOption('meta', scheme=Scheme(
-            Option('ttl', default=20, field_type=int)
+        DictOption('device', scheme=Scheme(
+            Option('rebuild_every', default=180, field_type=int)  # three minutes
         )),
         DictOption('transaction', scheme=Scheme(
             Option('ttl', default=300, field_type=int)  # five minutes

--- a/synse_server/server.py
+++ b/synse_server/server.py
@@ -6,7 +6,7 @@ import sys
 from sanic_prometheus import monitor
 
 import synse_server
-from synse_server import app, config, plugin
+from synse_server import app, config, plugin, tasks
 from synse_server.i18n import _
 from synse_server.log import logger, setup_logger
 
@@ -104,6 +104,10 @@ class Synse:
         # this info correctly.
         if self.log_header:
             sys.stdout.write(self._header)
+
+        # Add background tasks. This needs to be done at run so any tasks
+        # that take config options have the loaded config available to them.
+        tasks.register_with_app(self.app)
 
         # If application metrics are enabled, configure the application now.
         if config.options.get('metrics.enabled'):

--- a/synse_server/tasks.py
+++ b/synse_server/tasks.py
@@ -2,6 +2,7 @@
 
 import asyncio
 
+from synse_server import config
 from synse_server.cache import update_device_cache
 from synse_server.i18n import _
 from synse_server.log import logger
@@ -20,7 +21,7 @@ def register_with_app(app):
 
 async def _rebuild_device_cache():
     """Periodically rebuild the device cache."""
-    interval = 3 * 60  # 3 minutes
+    interval = config.options.get('cache.device.rebuild_every', 3 * 60)  # 3 minute default
 
     while True:
         logger.info(


### PR DESCRIPTION
fixes #255 

* removed old cache config now that the device cache items have no TTL
* add config option for task which rebuilds device cache
* fix issue where device cache used TTL - this is undesirable behavior since we rebuild the cache in a task
* moves task registration to pre-run instead of init, so they can access the loaded plugin config