### PR TITLE
fix background task registration

### DIFF
--- a/synse_server/app.py
+++ b/synse_server/app.py
@@ -2,7 +2,7 @@
 
 from sanic import Sanic
 
-from synse_server import errors, tasks
+from synse_server import errors
 from synse_server.api import http, websocket
 
 
@@ -30,8 +30,5 @@ def new_app():
     # Add favicon. This will add a favicon, preventing errors being logged when
     # a browser hits an endpoint and can't find the icon.
     app.static('/favicon.ico', '/etc/synse/static/favicon.ico')
-
-    # Add background tasks
-    tasks.register_with_app(app)
 
     return app

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -206,12 +206,4 @@ def state_reading():
 def synse_app():
     """Fixture to return an instance of the Synse Sanic application for testing."""
 
-    # Prevent background tasks from being registered on the app being used for
-    # its test client. This speeds things up slightly and prevents premature task
-    # termination warnings in the test output.
-    orig = app.tasks.register_with_app
-    app.tasks.register_with_app = lambda *args, **kwargs: None
-
     yield app.new_app()
-
-    app.tasks.register_with_app = orig


### PR DESCRIPTION
Fixes a bug in the background task registration, where the registration moved from app.py to server.py, but was not removed from app.py, causing it to be called twice at different points in the server lifecycle, so it was attached to different asyncio loops.