### PR TITLE
bugfix: always refresh plugins when rebuilding device cache

### DIFF
--- a/synse/locale/en_US/LC_MESSAGES/synse.po
+++ b/synse/locale/en_US/LC_MESSAGES/synse.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Synse Server VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-01-14 09:58-0500\n"
+"POT-Creation-Date: 2019-06-24 14:01-0400\n"
 "PO-Revision-Date: 2019-01-14 09:58-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en_US\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.7.0\n"
 
 #: synse/cache.py:49
 msgid "Setting cache configuration: {}"
@@ -39,7 +39,7 @@ msgstr ""
 msgid "Building the device capabilities cache"
 msgstr ""
 
-#: synse/cache.py:379 synse/cache.py:445
+#: synse/cache.py:379
 msgid "Manager has no plugins - registering plugins"
 msgstr ""
 
@@ -59,23 +59,27 @@ msgstr ""
 msgid "Building the device cache"
 msgstr ""
 
-#: synse/cache.py:449
+#: synse/cache.py:444
+msgid "re-registering plugins prior to cache rebuild"
+msgstr ""
+
+#: synse/cache.py:448
 msgid "Plugins to scan: {}"
 msgstr ""
 
-#: synse/cache.py:477
+#: synse/cache.py:480
 msgid "Failed to get device info for plugin: {}"
 msgstr ""
 
-#: synse/cache.py:484
+#: synse/cache.py:487
 msgid "Failed to scan all plugins: {}"
 msgstr ""
 
-#: synse/cache.py:502
+#: synse/cache.py:505
 msgid "Building the scan cache"
 msgstr ""
 
-#: synse/cache.py:637
+#: synse/cache.py:640
 msgid "Building the info cache"
 msgstr ""
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -79,6 +79,15 @@ def patch_device_info(monkeypatch):
 
 
 @pytest.fixture()
+def patch_register_plugins(monkeypatch):
+    """Fixture to monkeypatch the register_plugins method, so it does nothing, as
+    plugins are manually registered for test cases."""
+    def do_nothing():
+        pass
+    monkeypatch.setattr(cache, 'register_plugins', do_nothing)
+
+
+@pytest.fixture()
 def plugin_context(tmpdir):
     """Fixture to setup and teardown the test context for creating plugins."""
 
@@ -243,7 +252,7 @@ async def test_get_device_meta_not_found(clear_caches):
 
 
 @pytest.mark.asyncio
-async def test_get_device_info_cache_ok(plugin_context, clear_caches):
+async def test_get_device_info_cache_ok(patch_register_plugins, plugin_context, clear_caches):
     """Get the device info cache."""
 
     # create & register new plugin
@@ -284,7 +293,7 @@ async def test_get_device_info_cache_empty(plugin_context, clear_caches):
 
 
 @pytest.mark.asyncio
-async def test_get_device_info_cache_exist(plugin_context, clear_caches):
+async def test_get_device_info_cache_exist(patch_register_plugins, plugin_context, clear_caches):
     """Get the existing device info cache."""
 
     # create & register new plugin
@@ -335,7 +344,7 @@ async def test_get_device_info_cache_total_failure(plugin_context, clear_caches)
 
 
 @pytest.mark.asyncio
-async def test_get_device_info_cache_partial_failure(plugin_context, clear_caches):
+async def test_get_device_info_cache_partial_failure(patch_register_plugins, plugin_context, clear_caches):
     """Get the device info cache when some plugins fail to respond."""
 
     # create & register new plugins


### PR DESCRIPTION
fixes #317 

All this really does is remove the check to only re-register plugins if there are none. This will cause plugins to be re-registered every time the device cache is rebuilt, which happens periodically regardless of whether or not a cache rebuild is forced.