### PR TITLE
fix bug with emulator install script

### DIFF
--- a/bin/install_emulator.sh
+++ b/bin/install_emulator.sh
@@ -30,7 +30,7 @@ data=$(curl -s https://api.github.com/repos/${EMULATOR_REPO}/releases/latest)
 bin_url=$(echo ${data} | jq '.assets[] | select(.name | contains("linux_amd64")) | .url ' | tr -d '"')
 
 # Download the binary
-curl -L -H "Accept: application/octet-stream" -o ${EMULATOR_BIN} ${bin_url}
+curl -L -H "Accept: application/octet-stream" ${bin_url} | tar -xz && mv synse-emulator-plugin ${EMULATOR_BIN}
 chmod +x ${EMULATOR_BIN}
 
 if [[ "$EMULATOR_OUT" ]]; then

--- a/emulator/config/device/lock.yaml
+++ b/emulator/config/device/lock.yaml
@@ -10,7 +10,7 @@ devices:
     metadata:
       model: emul8-lock
     outputs:
-      - type: lock.state
+      - type: lock.status
     instances:
       - info: Synse Door Lock
         location: r1vec


### PR DESCRIPTION
This should fix #323 

The emulator installation script installed a gzipped tarball of the binary instead of the binary itself. This is due to the fact that we had updated the release pipeline for the emulator plugin, where it no longer uploaded the binary as a release asset, but a tarball of it. 

This PR:
- extracts the binary from the tarball 
- updates emulator config to be in line with recent updates to the emulator
