### PR TITLE
add initial config for docker app

### DIFF
--- a/synse-with-emulator.dockerapp
+++ b/synse-with-emulator.dockerapp
@@ -1,17 +1,20 @@
-#
-# docker-compose.yml
-#
-# A simple deployment of Synse Server with an emulator plugin
-# instance. Useful for learning, testing, and debugging.
-#
+# Application metadata
+version: 0.1.0
+name: synse-with-emulator
+description: Synse Server deployed with an emulator as the plugin backend.
+maintainers:
+  - name: edaniszewski
+    email: erick@vapor.io
 
+---
+# Application compose file
 version: '3.4'
 services:
   synse-server:
     container_name: synse-server
     image: vaporio/synse-server:v3.0.0-alpha.5
     ports:
-    - '5000:5000'
+    - '${port}:5000'
     environment:
       SYNSE_LOGGING: debug
       SYNSE_PLUGIN_TCP: emulator-plugin:5001
@@ -30,3 +33,7 @@ services:
     expose:
     - '5001'
     command: ['--debug']
+
+---
+# Default values for application parameters.
+port: 5000


### PR DESCRIPTION
related to #306 

docker community edition (for mac at least) dropped a new release which brings initial support for `docker app`. This PR adds a dockerapp file for the synse + emulator composefile. Still probably some work to be done here and playing around with where to push it so it can be easily used by others, but just parking this here for now.