### PR TITLE
update tag query behavior to allow for multiple tag groups

### DIFF
--- a/synse_server/api/http.py
+++ b/synse_server/api/http.py
@@ -141,7 +141,7 @@ async def plugin_health(request):
 @v3.route('/scan')
 @v3.route('/device')
 async def scan(request):
-    """List the devices that Synse knows about,
+    """List the devices that Synse knows about.
 
     This endpoint provides an aggregated view of all devices exposed to
     Synse Server by each of the registered plugins. By default, the scan
@@ -150,9 +150,12 @@ async def scan(request):
     Query Parameters:
         ns: The default namespace to use for specified tags without explicit namespaces.
             Only one default namespace may be specified. (default: ``default``)
-        tags: The tags to filter devices on. If specifying multiple tags, they can
-            be passed in as a comma-separated list, e.g. ``?tags=tag1,tag2,tag3``,
-            or via multiple ``tags`` parameters, e.g. ``?tags=tag1&tags=tag2&tags=tag3``.
+        tags: The tags to filter devices by. Multiple tag groups may be specified by
+            providing multiple ``tags`` query parameters, e.g. ``?tags=foo&tags=bar``.
+            Each tag group may consist of one or more comma-separated tags. Each tag
+            group only selects devices which match all of the tags in the group. If
+            multiple tag groups are specified, the result is the union of the matches
+            from each individual tag group.
         force: Force a re-scan (rebuild the internal cache). This will take longer than
             a scan which uses the cache. (default: false)
         sort: Specify the fields to sort by. Multiple fields may be specified as a
@@ -176,11 +179,11 @@ async def scan(request):
             )
         namespace = param_ns[0]
 
-    tags = []
+    tag_groups = []
     param_tags = request.args.getlist('tags')
     if param_tags:
-        for tag in param_tags:
-            tags.extend(tag.split(','))
+        for group in param_tags:
+            tag_groups.append(group.split(','))
 
     force = request.args.get('force', 'false').lower() == 'true'
 
@@ -196,7 +199,7 @@ async def scan(request):
     return utils.http_json_response(
         await cmd.scan(
             ns=namespace,
-            tags=tags,
+            tag_groups=tag_groups,
             force=force,
             sort=sort_keys,
         ),
@@ -269,9 +272,12 @@ async def read(request):
     Query Parameters:
         ns: The default namespace to use for specified tags without explicit namespaces.
             Only one default namespace may be specified. (default: ``default``)
-        tags: The tags to filter devices on. If specifying multiple tags, they can
-            be passed in as a comma-separated list, e.g. ``?tags=tag1,tag2,tag3``,
-            or via multiple ``tags`` parameters, e.g. ``?tags=tag1&tags=tag2&tags=tag3``.
+        tags: The tags to filter devices by. Multiple tag groups may be specified by
+            providing multiple ``tags`` query parameters, e.g. ``?tags=foo&tags=bar``.
+            Each tag group may consist of one or more comma-separated tags. Each tag
+            group only selects devices which match all of the tags in the group. If
+            multiple tag groups are specified, the result is the union of the matches
+            from each individual tag group.
 
     HTTP Codes:
         * 200: OK
@@ -289,16 +295,16 @@ async def read(request):
             )
         namespace = param_ns[0]
 
-    tags = []
+    tag_groups = []
     param_tags = request.args.getlist('tags')
     if param_tags:
-        for tag in param_tags:
-            tags.extend(tag.split(','))
+        for group in param_tags:
+            tag_groups.append(group.split(','))
 
     return utils.http_json_response(
         await cmd.read(
             ns=namespace,
-            tags=tags,
+            tag_groups=tag_groups,
         ),
     )
 

--- a/synse_server/api/websocket.py
+++ b/synse_server/api/websocket.py
@@ -252,12 +252,18 @@ class MessageHandler:
         force = payload.data.get('force', False)
         sort_keys = 'plugin,sortIndex,id'
 
+        # If tags are specified and all elements in the tags parameter
+        # are strings, they are part of a single tag group. Nest them
+        # appropriately.
+        if len(tags) != 0 and all(isinstance(t, str) for t in tags):
+            tags = [tags]
+
         await self.ws.send(json.dumps({
             'id': payload.id,
             'event': 'response/device_summary',
             'data': await cmd.scan(
                 ns=ns,
-                tags=tags,
+                tag_groups=tags,
                 sort=sort_keys,
                 force=force,
             ),
@@ -303,12 +309,18 @@ class MessageHandler:
         ns = payload.data.get('ns', 'default')
         tags = payload.data.get('tags', [])
 
+        # If tags are specified and all elements in the tags parameter
+        # are strings, they are part of a single tag group. Nest them
+        # appropriately.
+        if len(tags) != 0 and all(isinstance(t, str) for t in tags):
+            tags = [tags]
+
         await self.ws.send(json.dumps({
             'id': payload.id,
             'event': 'response/reading',
             'data': await cmd.read(
                 ns=ns,
-                tags=tags,
+                tag_groups=tags,
             ),
         }))
 

--- a/tests/unit/api/test_http.py
+++ b/tests/unit/api/test_http.py
@@ -400,7 +400,7 @@ class TestV3Scan:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
             force=False,
             sort='plugin,sortIndex,id',
         )
@@ -424,7 +424,7 @@ class TestV3Scan:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
             force=False,
             sort='plugin,sortIndex,id',
         )
@@ -500,7 +500,7 @@ class TestV3Scan:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns=expected,
-            tags=[],
+            tag_groups=[],
             force=False,
             sort='plugin,sortIndex,id',
         )
@@ -541,7 +541,7 @@ class TestV3Scan:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
             force=False,
             sort=expected,
         )
@@ -591,7 +591,7 @@ class TestV3Scan:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
             force=expected,
             sort='plugin,sortIndex,id',
         )
@@ -599,13 +599,13 @@ class TestV3Scan:
     @pytest.mark.parametrize(
         'qparam,expected', [
             ('?tags=', []),
-            ('?tags=a,b,c', ['a', 'b', 'c']),
-            ('?tags=a&tags=b&tags=c', ['a', 'b', 'c']),
-            ('?tags=default/foo', ['default/foo']),
-            ('?tags=default/foo:bar', ['default/foo:bar']),
-            ('?tags=foo:bar', ['foo:bar']),
-            ('?tags=foo:bar&tags=default/foo:baz&tags=vapor', ['foo:bar', 'default/foo:baz', 'vapor']),  # noqa: E501
-            ('?tags=default/foo,bar&tags=vapor/test', ['default/foo', 'bar', 'vapor/test']),
+            ('?tags=a,b,c', [['a', 'b', 'c']]),
+            ('?tags=a&tags=b&tags=c', [['a'], ['b'], ['c']]),
+            ('?tags=default/foo', [['default/foo']]),
+            ('?tags=default/foo:bar', [['default/foo:bar']]),
+            ('?tags=foo:bar', [['foo:bar']]),
+            ('?tags=foo:bar&tags=default/foo:baz&tags=vapor', [['foo:bar'], ['default/foo:baz'], ['vapor']]),  # noqa: E501
+            ('?tags=default/foo,bar&tags=vapor/test', [['default/foo', 'bar'], ['vapor/test']]),
         ]
     )
     def test_param_tags(self, synse_app, qparam, expected):
@@ -635,7 +635,7 @@ class TestV3Scan:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=expected,
+            tag_groups=expected,
             force=False,
             sort='plugin,sortIndex,id',
         )
@@ -894,7 +894,7 @@ class TestV3Read:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
         )
 
     def test_error(self, synse_app):
@@ -916,7 +916,7 @@ class TestV3Read:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
         )
 
     def test_invalid_multiple_ns(self, synse_app):
@@ -939,13 +939,13 @@ class TestV3Read:
     @pytest.mark.parametrize(
         'qparam,expected', [
             ('?tags=', []),
-            ('?tags=a,b,c', ['a', 'b', 'c']),
-            ('?tags=a&tags=b&tags=c', ['a', 'b', 'c']),
-            ('?tags=default/foo', ['default/foo']),
-            ('?tags=default/foo:bar', ['default/foo:bar']),
-            ('?tags=foo:bar', ['foo:bar']),
-            ('?tags=foo:bar&tags=default/foo:baz&tags=vapor', ['foo:bar', 'default/foo:baz', 'vapor']),  # noqa: E501
-            ('?tags=default/foo,bar&tags=vapor/test', ['default/foo', 'bar', 'vapor/test']),
+            ('?tags=a,b,c', [['a', 'b', 'c']]),
+            ('?tags=a&tags=b&tags=c', [['a'], ['b'], ['c']]),
+            ('?tags=default/foo', [['default/foo']]),
+            ('?tags=default/foo:bar', [['default/foo:bar']]),
+            ('?tags=foo:bar', [['foo:bar']]),
+            ('?tags=foo:bar&tags=default/foo:baz&tags=vapor', [['foo:bar'], ['default/foo:baz'], ['vapor']]),  # noqa: E501
+            ('?tags=default/foo,bar&tags=vapor/test', [['default/foo', 'bar'], ['vapor/test']]),
         ]
     )
     def test_param_tags(self, synse_app, qparam, expected):
@@ -970,7 +970,7 @@ class TestV3Read:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=expected,
+            tag_groups=expected,
         )
 
     @pytest.mark.parametrize(
@@ -1005,7 +1005,7 @@ class TestV3Read:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns=expected,
-            tags=[],
+            tag_groups=[],
         )
 
 
@@ -1849,7 +1849,7 @@ class TestV3Device:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
             force=False,
             sort='plugin,sortIndex,id',
         )
@@ -1873,7 +1873,7 @@ class TestV3Device:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
             force=False,
             sort='plugin,sortIndex,id',
         )
@@ -1947,7 +1947,7 @@ class TestV3Device:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns=expected,
-            tags=[],
+            tag_groups=[],
             force=False,
             sort='plugin,sortIndex,id',
         )
@@ -1988,7 +1988,7 @@ class TestV3Device:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
             force=False,
             sort=expected,
         )
@@ -2038,7 +2038,7 @@ class TestV3Device:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
             force=expected,
             sort='plugin,sortIndex,id',
         )
@@ -2046,13 +2046,13 @@ class TestV3Device:
     @pytest.mark.parametrize(
         'qparam,expected', [
             ('?tags=', []),
-            ('?tags=a,b,c', ['a', 'b', 'c']),
-            ('?tags=a&tags=b&tags=c', ['a', 'b', 'c']),
-            ('?tags=default/foo', ['default/foo']),
-            ('?tags=default/foo:bar', ['default/foo:bar']),
-            ('?tags=foo:bar', ['foo:bar']),
-            ('?tags=foo:bar&tags=default/foo:baz&tags=vapor', ['foo:bar', 'default/foo:baz', 'vapor']),  # noqa: E501
-            ('?tags=default/foo,bar&tags=vapor/test', ['default/foo', 'bar', 'vapor/test']),
+            ('?tags=a,b,c', [['a', 'b', 'c']]),
+            ('?tags=a&tags=b&tags=c', [['a'], ['b'], ['c']]),
+            ('?tags=default/foo', [['default/foo']]),
+            ('?tags=default/foo:bar', [['default/foo:bar']]),
+            ('?tags=foo:bar', [['foo:bar']]),
+            ('?tags=foo:bar&tags=default/foo:baz&tags=vapor', [['foo:bar'], ['default/foo:baz'], ['vapor']]),  # noqa: E501
+            ('?tags=default/foo,bar&tags=vapor/test', [['default/foo', 'bar'], ['vapor/test']]),
         ]
     )
     def test_enumerate_param_tags(self, synse_app, qparam, expected):
@@ -2082,7 +2082,7 @@ class TestV3Device:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=expected,
+            tag_groups=expected,
             force=False,
             sort='plugin,sortIndex,id',
         )

--- a/tests/unit/api/test_websocket.py
+++ b/tests/unit/api/test_websocket.py
@@ -331,7 +331,7 @@ class TestMessageHandler:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
             sort='plugin,sortIndex,id',
             force=False,
         )
@@ -357,7 +357,7 @@ class TestMessageHandler:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
             sort='plugin,sortIndex,id',
             force=True,
         )
@@ -383,7 +383,7 @@ class TestMessageHandler:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='vapor',
-            tags=[],
+            tag_groups=[],
             sort='plugin,sortIndex,id',
             force=False,
         )
@@ -395,7 +395,33 @@ class TestMessageHandler:
         }))
 
     @pytest.mark.asyncio
-    async def test_request_scan_data_tags(self):
+    async def test_request_scan_data_tags_one_group(self):
+        with asynctest.patch('synse_server.cmd.scan') as mock_cmd:
+            with asynctest.patch('websockets.WebSocketCommonProtocol.send') as mock_send:
+                mock_cmd.return_value = [{
+                    'key': 'value',
+                }]
+
+                p = make_payload(data={'tags': [['ns/ann:lab', 'foo']]})
+                m = websocket.MessageHandler(websockets.WebSocketCommonProtocol())
+                await m.handle_request_scan(p)
+
+        mock_cmd.assert_called_once()
+        mock_cmd.assert_called_with(
+            ns='default',
+            tag_groups=[['ns/ann:lab', 'foo']],
+            sort='plugin,sortIndex,id',
+            force=False,
+        )
+        mock_send.assert_called_once()
+        mock_send.assert_called_with(json.dumps({
+            'id': 'testing',
+            'event': 'response/device_summary',
+            'data': mock_cmd.return_value,
+        }))
+
+    @pytest.mark.asyncio
+    async def test_request_scan_data_tags_implicit_group(self):
         with asynctest.patch('synse_server.cmd.scan') as mock_cmd:
             with asynctest.patch('websockets.WebSocketCommonProtocol.send') as mock_send:
                 mock_cmd.return_value = [{
@@ -409,7 +435,33 @@ class TestMessageHandler:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=['ns/ann:lab', 'foo'],
+            tag_groups=[['ns/ann:lab', 'foo']],
+            sort='plugin,sortIndex,id',
+            force=False,
+        )
+        mock_send.assert_called_once()
+        mock_send.assert_called_with(json.dumps({
+            'id': 'testing',
+            'event': 'response/device_summary',
+            'data': mock_cmd.return_value,
+        }))
+
+    @pytest.mark.asyncio
+    async def test_request_scan_data_tags_multiple_groups(self):
+        with asynctest.patch('synse_server.cmd.scan') as mock_cmd:
+            with asynctest.patch('websockets.WebSocketCommonProtocol.send') as mock_send:
+                mock_cmd.return_value = [{
+                    'key': 'value',
+                }]
+
+                p = make_payload(data={'tags': [['ns/ann:lab', 'foo'], ['bar']]})
+                m = websocket.MessageHandler(websockets.WebSocketCommonProtocol())
+                await m.handle_request_scan(p)
+
+        mock_cmd.assert_called_once()
+        mock_cmd.assert_called_with(
+            ns='default',
+            tag_groups=[['ns/ann:lab', 'foo'], ['bar']],
             sort='plugin,sortIndex,id',
             force=False,
         )
@@ -549,7 +601,7 @@ class TestMessageHandler:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=[],
+            tag_groups=[],
         )
         mock_send.assert_called_once()
         mock_send.assert_called_with(json.dumps({
@@ -573,7 +625,7 @@ class TestMessageHandler:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='foo',
-            tags=[],
+            tag_groups=[],
         )
         mock_send.assert_called_once()
         mock_send.assert_called_with(json.dumps({
@@ -583,7 +635,31 @@ class TestMessageHandler:
         }))
 
     @pytest.mark.asyncio
-    async def test_request_read_data_tags(self):
+    async def test_request_read_data_tags_one_group(self):
+        with asynctest.patch('synse_server.cmd.read') as mock_cmd:
+            with asynctest.patch('websockets.WebSocketCommonProtocol.send') as mock_send:
+                mock_cmd.return_value = [{
+                    'key': 'value',
+                }]
+
+                p = make_payload(data={'tags': [['foo', 'bar']]})
+                m = websocket.MessageHandler(websockets.WebSocketCommonProtocol())
+                await m.handle_request_read(p)
+
+        mock_cmd.assert_called_once()
+        mock_cmd.assert_called_with(
+            ns='default',
+            tag_groups=[['foo', 'bar']],
+        )
+        mock_send.assert_called_once()
+        mock_send.assert_called_with(json.dumps({
+            'id': 'testing',
+            'event': 'response/reading',
+            'data': mock_cmd.return_value,
+        }))
+
+    @pytest.mark.asyncio
+    async def test_request_read_data_tags_implicit_group(self):
         with asynctest.patch('synse_server.cmd.read') as mock_cmd:
             with asynctest.patch('websockets.WebSocketCommonProtocol.send') as mock_send:
                 mock_cmd.return_value = [{
@@ -597,7 +673,31 @@ class TestMessageHandler:
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
             ns='default',
-            tags=['foo', 'bar'],
+            tag_groups=[['foo', 'bar']],
+        )
+        mock_send.assert_called_once()
+        mock_send.assert_called_with(json.dumps({
+            'id': 'testing',
+            'event': 'response/reading',
+            'data': mock_cmd.return_value,
+        }))
+
+    @pytest.mark.asyncio
+    async def test_request_read_data_tags_multiple_groups(self):
+        with asynctest.patch('synse_server.cmd.read') as mock_cmd:
+            with asynctest.patch('websockets.WebSocketCommonProtocol.send') as mock_send:
+                mock_cmd.return_value = [{
+                    'key': 'value',
+                }]
+
+                p = make_payload(data={'tags': [['foo', 'bar'], ['baz']]})
+                m = websocket.MessageHandler(websockets.WebSocketCommonProtocol())
+                await m.handle_request_read(p)
+
+        mock_cmd.assert_called_once()
+        mock_cmd.assert_called_with(
+            ns='default',
+            tag_groups=[['foo', 'bar'], ['baz']],
         )
         mock_send.assert_called_once()
         mock_send.assert_called_with(json.dumps({

--- a/tests/unit/cmd/test_read.py
+++ b/tests/unit/cmd/test_read.py
@@ -17,7 +17,7 @@ async def test_read_no_plugins(mocker):
     )
 
     # --- Test case -----------------------------
-    resp = await cmd.read('default', ['default/foo'])
+    resp = await cmd.read('default', [['default/foo']])
     assert len(resp) == 0
 
     mock_read.assert_not_called()
@@ -40,7 +40,7 @@ async def test_read_fails_read(mocker, simple_plugin):
     simple_plugin.active = True
 
     with pytest.raises(errors.ServerError):
-        await cmd.read('default', ['default/foo'])
+        await cmd.read('default', [['default/foo']])
 
     assert simple_plugin.active is False
 
@@ -84,7 +84,7 @@ async def test_read_fails_read_multiple_one_fail(mocker, simple_plugin, temperat
     error_plugin.active = True
 
     with pytest.raises(errors.ServerError):
-        await cmd.read('default', ['default/foo'])
+        await cmd.read('default', [['default/foo']])
 
     assert simple_plugin.active is True
     assert error_plugin.active is False
@@ -147,7 +147,7 @@ async def test_read_ok_no_tags(mocker, simple_plugin, temperature_reading, humid
     assert simple_plugin.active is True
 
     mock_read.assert_called_once()
-    mock_read.assert_called_with(tags=[])
+    mock_read.assert_called_with()
 
 
 @pytest.mark.asyncio
@@ -169,17 +169,13 @@ async def test_read_ok_tags_with_ns(mocker, simple_plugin, state_reading):
     # Set the simple_plugin to active to start.
     simple_plugin.active = True
 
-    resp = await cmd.read('default', ['foo/bar', 'vapor/ware'])
+    resp = await cmd.read('default', [['foo/bar', 'vapor/ware']])
+
+    # Note: There are two plugins defined, so we should expect each
+    # plugin to return a reading. Since the fixture returns the same reading
+    # at the same timestamp, we take this to be the same reading and deduplicate
+    # it, hence we only get one reading here.
     assert resp == [
-        {  # from state_reading fixture
-            'device': 'ccc',
-            'timestamp': '2019-04-22T13:30:00Z',
-            'type': 'state',
-            'device_type': 'led',
-            'value': 'on',
-            'unit': None,
-            'context': {},
-        },
         {  # from state_reading fixture
             'device': 'ccc',
             'timestamp': '2019-04-22T13:30:00Z',
@@ -219,17 +215,13 @@ async def test_read_ok_tags_without_ns(mocker, simple_plugin, state_reading):
     # Set the simple_plugin to active to start.
     simple_plugin.active = True
 
-    resp = await cmd.read('default', ['foo', 'bar', 'vapor/ware'])
+    resp = await cmd.read('default', [['foo', 'bar', 'vapor/ware']])
+
+    # Note: There are two plugins defined, so we should expect each
+    # plugin to return a reading. Since the fixture returns the same reading
+    # at the same timestamp, we take this to be the same reading and deduplicate
+    # it, hence we only get one reading here.
     assert resp == [
-        {  # from state_reading fixture
-            'device': 'ccc',
-            'timestamp': '2019-04-22T13:30:00Z',
-            'type': 'state',
-            'device_type': 'led',
-            'value': 'on',
-            'unit': None,
-            'context': {},
-        },
         {  # from state_reading fixture
             'device': 'ccc',
             'timestamp': '2019-04-22T13:30:00Z',

--- a/tests/unit/cmd/test_scan.py
+++ b/tests/unit/cmd/test_scan.py
@@ -23,7 +23,7 @@ async def test_scan_no_devices():
         with asynctest.patch('synse_server.cache.get_devices') as mock_get:
             mock_get.return_value = []
 
-            resp = await cmd.scan('default', ['foo'], '', force=False)
+            resp = await cmd.scan('default', [['foo']], '', force=False)
             assert len(resp) == 0
 
     mock_update.assert_not_called()
@@ -38,7 +38,7 @@ async def test_scan_get_devices_errors():
             mock_get.side_effect = ValueError()
 
             with pytest.raises(errors.ServerError):
-                await cmd.scan('default', ['foo', 'test/bar'], '', force=False)
+                await cmd.scan('default', [['foo', 'test/bar']], '', force=False)
 
     mock_update.assert_not_called()
     mock_get.assert_called_once()
@@ -77,7 +77,7 @@ async def test_scan_invalid_keys():
             ]
 
             with pytest.raises(errors.InvalidUsage):
-                await cmd.scan('default', ['foo'], 'not-a-key,tags', force=False)
+                await cmd.scan('default', [['foo']], 'not-a-key,tags', force=False)
 
     mock_update.assert_not_called()
     mock_get.assert_called_once()
@@ -115,7 +115,7 @@ async def test_scan_ok():
                 ),
             ]
 
-            resp = await cmd.scan('default', ['foo'], 'plugin,sortIndex,id', force=True)
+            resp = await cmd.scan('default', [['foo']], 'plugin,sortIndex,id', force=True)
             assert len(resp) == 3
             assert resp[0]['id'] == '1'
             assert resp[1]['id'] == '3'
@@ -157,7 +157,7 @@ async def test_scan_sort_ok():
                 ),
             ]
 
-            resp = await cmd.scan('default', ['foo'], 'type,plugin,id', force=True)
+            resp = await cmd.scan('default', [['foo']], 'type,plugin,id', force=True)
             assert len(resp) == 3
             assert resp[0]['id'] == '3'
             assert resp[1]['id'] == '1'


### PR DESCRIPTION
fixes #329 

Previously, endpoints which take tags as params could take them as a comma separated list, or in multiple `tags` params. For example, all of the below would be equivalent:
- `?tags=foo,bar,baz`
- `?tags=foo&tags=bar,baz`
- `?tags=foo,bar&tags=baz`
- `?tags=foo&tags=bar&tags=baz`

All the tags would be collected into a single tag group which would be used to filter the devices. If you wanted to get all fan and led devices, e.g., this would need to be done in two requests
- `?tags=system/type:fan`
- `?tags=system/type:led`

Since combining the tags into a single request `?tags=system/type:fan,system/type:led` would not work, as there is no device which would have both of those tags (cannot have two system-assigned types). 

With this PR, you can specify multiple tag groups from query params, so you can get back both all led and fan devices from a single request, e.g. `?tags=system/type:fan&tags=system/type:led`