### PR TITLE
add metadata to scan output

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,7 +14,7 @@ coverage==4.5.4           # via pytest-cov
 idna-ssl==1.1.0           # via aiohttp
 idna==2.8                 # via idna-ssl, yarl
 importlib-metadata==0.19  # via pluggy, pytest
-more-itertools==7.2.0     # via pytest
+more-itertools==7.2.0     # via pytest, zipp
 multidict==4.5.2          # via aiohttp, yarl
 packaging==19.1           # via pytest
 pluggy==0.12.0            # via pytest
@@ -23,9 +23,9 @@ pyparsing==2.4.2          # via packaging
 pytest-asyncio==0.10.0
 pytest-cov==2.7.1
 pytest-mock==1.10.4
-pytest==5.1.0
+pytest==5.1.1
 six==1.12.0               # via packaging
 typing-extensions==3.7.4  # via aiohttp
 wcwidth==0.1.7            # via pytest
 yarl==1.3.0               # via aiohttp
-zipp==0.5.2               # via importlib-metadata
+zipp==0.6.0               # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ requests==2.22.0
 rfc3986==1.3.2            # via httpcore
 rsa==4.0                  # via google-auth
 sanic-prometheus==0.1.10
-sanic==19.6.2
+sanic==19.6.3
 six==1.12.0               # via google-auth, grpcio, kubernetes, protobuf, python-dateutil, structlog, websocket-client
 structlog==19.1.0
 synse-grpc==3.0.0a3
@@ -43,7 +43,7 @@ ujson==1.35               # via sanic
 urllib3==1.25.3           # via kubernetes, requests
 uvloop==0.13.0            # via sanic
 websocket-client==0.56.0  # via kubernetes
-websockets==6.0           # via sanic
+websockets==7.0           # via sanic
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.1.0        # via kubernetes, protobuf
+# setuptools==41.2.0        # via kubernetes, protobuf

--- a/synse_server/__init__.py
+++ b/synse_server/__init__.py
@@ -3,7 +3,7 @@ and virtual devices.
 """
 
 __title__ = 'synse_server'
-__version__ = '3.0.0-alpha.7'
+__version__ = '3.0.0-alpha.8'
 __api_version__ = 'v3'
 __description__ = 'An API to monitor and control physical and virtual devices.'
 __author__ = 'Vapor IO'

--- a/synse_server/cmd/scan.py
+++ b/synse_server/cmd/scan.py
@@ -91,5 +91,6 @@ async def scan(ns, tag_groups, sort, force=False):
             'type': device.type,
             'plugin': device.plugin,
             'tags': [utils.tag_string(tag) for tag in device.tags],
+            'metadata': dict(device.metadata),
         })
     return response

--- a/tests/unit/cmd/test_scan.py
+++ b/tests/unit/cmd/test_scan.py
@@ -95,7 +95,10 @@ async def test_scan_ok():
                     plugin='abc',
                     tags=[
                         api.V3Tag(namespace='default', label='foo')
-                    ]
+                    ],
+                    metadata={
+                        'foo': 'bar',
+                    },
                 ),
                 api.V3Device(
                     id='2',
@@ -120,6 +123,44 @@ async def test_scan_ok():
             assert resp[0]['id'] == '1'
             assert resp[1]['id'] == '3'
             assert resp[2]['id'] == '2'
+
+            assert resp == [
+                {
+                    'id': '1',
+                    'alias': '',
+                    'info': '',
+                    'type': 'foo',
+                    'plugin': 'abc',
+                    'tags': [
+                        'default/foo',
+                    ],
+                    'metadata': {
+                        'foo': 'bar'
+                    }
+                },
+                {
+                    'id': '3',
+                    'alias': '',
+                    'info': '',
+                    'type': 'bar',
+                    'plugin': 'abc',
+                    'tags': [
+                        'default/foo',
+                    ],
+                    'metadata': {}
+                },
+                {
+                    'id': '2',
+                    'alias': '',
+                    'info': '',
+                    'type': 'foo',
+                    'plugin': 'def',
+                    'tags': [
+                        'default/foo',
+                    ],
+                    'metadata': {}
+                },
+            ]
 
     mock_update.assert_called_once()
     mock_get.assert_called_once()


### PR DESCRIPTION
This PR:
- adds a 'metadata' field to the scan output, populated with the metadata (context) from the gRPC response
- updates deps
- bumps to 3.0.0-alpha.8


This addition to the scan output serves multiple purposes:
- exposes arbitrary device data to the user which can be used for additional filtering/aggregation
- makes devices easier to identify from a flat scan result, visually