### PR TITLE
websocket api bugfixes

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,26 +4,26 @@
 #
 #    pip-compile --output-file=requirements-test.txt test-requirements.in
 #
-aiohttp==3.5.4
+aiohttp==3.6.2
 async-timeout==3.0.1      # via aiohttp
 asynctest==0.13.0
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via aiohttp, packaging, pytest
+attrs==19.2.0             # via aiohttp, pytest
 chardet==3.0.4            # via aiohttp
 coverage==4.5.4           # via pytest-cov
 idna-ssl==1.1.0           # via aiohttp
 idna==2.8                 # via idna-ssl, yarl
-importlib-metadata==0.19  # via pluggy, pytest
+importlib-metadata==0.23  # via pluggy, pytest
 more-itertools==7.2.0     # via pytest, zipp
 multidict==4.5.2          # via aiohttp, yarl
-packaging==19.1           # via pytest
-pluggy==0.12.0            # via pytest
+packaging==19.2           # via pytest
+pluggy==0.13.0            # via pytest
 py==1.8.0                 # via pytest
 pyparsing==2.4.2          # via packaging
 pytest-asyncio==0.10.0
-pytest-cov==2.7.1
-pytest-mock==1.10.4
-pytest==5.1.1
+pytest-cov==2.8.1
+pytest-mock==1.11.1
+pytest==5.2.1
 six==1.12.0               # via packaging
 typing-extensions==3.7.4  # via aiohttp
 wcwidth==0.1.7            # via pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,12 @@
 #
 aiocache==0.11.1
 aiofiles==0.4.0           # via sanic
-bison==0.1.1
+bison==0.1.2
 cachetools==3.1.1         # via google-auth
-certifi==2019.6.16        # via httpcore, kubernetes, requests
+certifi==2019.9.11        # via httpcore, kubernetes, requests
 chardet==3.0.4            # via httpcore, requests
 google-auth==1.6.3        # via kubernetes
-grpcio==1.23.0
+grpcio==1.24.1
 h11==0.8.1                # via httpcore
 h2==3.1.1                 # via httpcore
 hpack==3.0.0              # via h2
@@ -23,10 +23,10 @@ kubernetes==10.0.1
 multidict==4.5.2          # via sanic
 oauthlib==3.1.0           # via requests-oauthlib
 prometheus-client==0.5.0  # via sanic-prometheus
-protobuf==3.9.1           # via synse-grpc
+protobuf==3.10.0          # via synse-grpc
 psutil==5.6.3             # via sanic-prometheus
-pyasn1-modules==0.2.6     # via google-auth
-pyasn1==0.4.6             # via pyasn1-modules, rsa
+pyasn1-modules==0.2.7     # via google-auth
+pyasn1==0.4.7             # via pyasn1-modules, rsa
 python-dateutil==2.8.0    # via kubernetes
 pyyaml==5.1.2
 requests-async==0.5.0     # via sanic
@@ -40,10 +40,10 @@ six==1.12.0               # via google-auth, grpcio, kubernetes, protobuf, pytho
 structlog==19.1.0
 synse-grpc==3.0.0a3
 ujson==1.35               # via sanic
-urllib3==1.25.3           # via kubernetes, requests
+urllib3==1.25.6           # via kubernetes, requests
 uvloop==0.13.0            # via sanic
 websocket-client==0.56.0  # via kubernetes
 websockets==7.0           # via sanic
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via kubernetes, protobuf
+# setuptools==41.4.0        # via kubernetes, protobuf

--- a/synse_server/__init__.py
+++ b/synse_server/__init__.py
@@ -3,7 +3,7 @@ and virtual devices.
 """
 
 __title__ = 'synse_server'
-__version__ = '3.0.0-alpha.8'
+__version__ = '3.0.0-alpha.9'
 __api_version__ = 'v3'
 __description__ = 'An API to monitor and control physical and virtual devices.'
 __author__ = 'Vapor IO'

--- a/synse_server/api/websocket.py
+++ b/synse_server/api/websocket.py
@@ -281,7 +281,7 @@ class MessageHandler:
         Args:
             payload (Payload): The message payload received from the WebSocket.
         """
-        ns = payload.data.get('ns', ['default'])
+        ns = payload.data.get('ns', [])
         ids = payload.data.get('ids', False)
 
         await self.ws.send(json.dumps({

--- a/synse_server/cmd/tags.py
+++ b/synse_server/cmd/tags.py
@@ -29,9 +29,9 @@ async def tags(*namespaces, with_id_tags=False):
         return ns in namespaces
 
     if not with_id_tags:
-        cached_tags = filter(lambda t: not t.startswith('system/id:'), cached_tags)
+        cached_tags = [t for t in cached_tags if not t.startswith('system/id:')]
 
     if namespaces:
-        cached_tags = filter(lambda t: matches_ns(t), cached_tags)
+        cached_tags = [t for t in cached_tags if matches_ns(t)]
 
     return sorted(cached_tags)

--- a/synse_server/cmd/transaction.py
+++ b/synse_server/cmd/transaction.py
@@ -47,6 +47,8 @@ async def transaction(transaction_id):
 
     status = synse_grpc.utils.to_dict(response)
     status['device'] = device
+    if status.get('context', {}).get('data'):
+        status['context']['data'] = status['context']['data'].decode('utf-8')
     return status
 
 

--- a/synse_server/cmd/write.py
+++ b/synse_server/cmd/write.py
@@ -31,7 +31,10 @@ async def write_async(device_id, payload):
             for txn in client.write_async(device_id=device_id, data=payload):
                 # Add the transaction to the cache
                 await cache.add_transaction(txn.id, txn.device, plugin.id)
-                response.append(utils.to_dict(txn))
+                rsp = utils.to_dict(txn)
+                if rsp.get('context', {}).get('data'):
+                    rsp['context']['data'] = rsp['context']['data'].decode('utf-8')
+                response.append(rsp)
     except Exception as e:
         raise errors.ServerError(
             _('error while issuing gRPC request: async write'),
@@ -67,6 +70,8 @@ async def write_sync(device_id, payload):
                 await cache.add_transaction(status.id, device_id, plugin.id)
                 s = utils.to_dict(status)
                 s['device'] = device_id
+                if s.get('context', {}).get('data'):
+                    s['context']['data'] = s['context']['data'].decode('utf-8')
                 response.append(s)
     except Exception as e:
         raise errors.ServerError(

--- a/tests/unit/api/test_websocket.py
+++ b/tests/unit/api/test_websocket.py
@@ -487,7 +487,6 @@ class TestMessageHandler:
 
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
-            'default',
             with_id_tags=False,
         )
         mock_send.assert_called_once()
@@ -537,7 +536,6 @@ class TestMessageHandler:
 
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
-            'default',
             with_id_tags=True,
         )
         mock_send.assert_called_once()


### PR DESCRIPTION
This PR:
- fixes a number of bugs around the websocket api discovered when implementing https://github.com/vapor-ware/synse-client-python/pull/29. these bugs include:
    - using "default" as the default value for a tags request, which would prevent all tags from being returned when no constraints are specified
    - fixed bug in tag filtering where apparently using `filter` prevented results from being collected properly -- now uses list comprehensions
    - fixed some bugs relating to `json` not being able to serialize bytes which are returned in some of the gRPC message responses. 
- updates tests
- updates dependencies
- bumps to `3.0.0-alpha.9`