### PR TITLE
update sanic-prometheus to use full url label

### DIFF
--- a/synse_server/server.py
+++ b/synse_server/server.py
@@ -116,7 +116,10 @@ class Synse:
         # If application metrics are enabled, configure the application now.
         if config.options.get('metrics.enabled'):
             logger.info(_('application performance metrics enabled'))
-            monitor(self.app).expose_endpoint()
+            monitor(
+                app=self.app,
+                endpoint_type='url',
+            ).expose_endpoint()
 
         # Load the SSL configuration, if defined.
         ssl_context = None


### PR DESCRIPTION
This PR:
- updates the initialization of the sanic-prometheus monitor in order to get the full url as a label


Without specifying `endpoint_type='url'`, the monitor defaults to `endpoint_type='url:1'` which signifies that it should only use the first element of the url. Since most of our endpoints are kept under the `/v3` root, this lead to the gathered metrics falling under only `/test` and `/v3` which isn't too helpful.

This PR allows the full URL to be used. This will include URLs for specific resources (e.g. `/v3/read/1232358127462`), so it may get messy with lots of requests, but that isn't terrible since it could help to identify devices which are slow to respond, etc.