### PR TITLE
fix bug in websocket close callback

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -25,7 +25,7 @@ pytest-cov==2.8.1
 pytest-mock==1.11.2
 pytest==5.2.2
 six==1.12.0               # via packaging
-typing-extensions==3.7.4  # via aiohttp
+typing-extensions==3.7.4.1  # via aiohttp
 wcwidth==0.1.7            # via pytest
 yarl==1.3.0               # via aiohttp
 zipp==0.6.0               # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ ujson==1.35               # via sanic
 urllib3==1.25.6           # via kubernetes, requests
 uvloop==0.13.0            # via sanic
 websocket-client==0.56.0  # via kubernetes
-websockets==7.0
+websockets==8.0.2
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.4.0        # via kubernetes, protobuf
+# setuptools==41.6.0        # via kubernetes, protobuf

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'sanic>=0.8.0',
         'prometheus-client',
         'structlog',
-        'websockets==7.0',  # fixme: temporarily pin
+        'websockets',
         'synse-grpc==3.0.0a4',  # fixme: for alpha v3 testing; update to stable v3 release
     ],
     zip_safe=False,

--- a/synse_server/api/websocket.py
+++ b/synse_server/api/websocket.py
@@ -108,10 +108,13 @@ class MessageHandler:
 
         # When the websocket is cancelled or terminates, ensure that the MessageHandler
         # associated with that websocket is stopped and cleaned up.
-        if ws.close_connection_task is not None:
+        #
+        # As of websockets==8.0.0, the `close_connection_task` member will not exit until
+        # the client is connected. Check both that the attribute exists and that it is not
+        # None before attempting to add a done callback to the task.
+        if hasattr(ws, 'close_connection_task') and ws.close_connection_task is not None:
             ws.close_connection_task.add_done_callback(self.stop)
 
-        # todo - if this don't work, just use threads.
         self.tasks = []
 
     async def run(self):


### PR DESCRIPTION
This PR:
- updates deps, bringing `websockets` to 8.0.2
- fixes a bug due to a breaking change in dependency update - now, the close task will not exist on init, but will be created on connect. this doesn't seem like it would have been an issue for normal run of synse-server, but it posed issues with tests. this adds a check to ensure the attribute exists.

fixes #340 