### PR TITLE
bugfix: cannot get response size from body attr for streamed responses

### DIFF
--- a/synse_server/metrics.py
+++ b/synse_server/metrics.py
@@ -115,7 +115,10 @@ class Monitor:
 
                 # We cannot use Content-Length header since that has not yet been
                 # calculated and added to the response headers.
-                if response.body is not None:
+                #
+                # Streaming responses do not have a 'body' attribute, so we cannot
+                # collect this data in those cases.
+                if hasattr(response, 'body') and response.body is not None:
                     self.http_resp_bytes.labels(*labels).inc(len(response.body))
 
         @self.app.route('/metrics', methods=['GET'])


### PR DESCRIPTION
This PR:
- fixes a bug in the metrics collection where streamed responses will raise an exception due to the streamed response not having a `body` attribute

```
timestamp='2019-11-07T19:25:23.740522Z' level='debug' event='processing request' method='GET' ip='10.48.29.113' path='/v3/readcache' params={'start': ['2019-11-07T19:25:18Z']}
Exception occurred in one of response middleware handlers
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/sanic/app.py", line 983, in handle_request
    request, response
  File "/usr/local/lib/python3.6/site-packages/sanic/app.py", line 1271, in _run_response_middleware
    _response = await _response
  File "/usr/local/lib/python3.6/site-packages/synse_server/metrics.py", line 118, in before_response
    if response.body is not None:
AttributeError: 'StreamingHTTPResponse' object has no attribute 'body'
```