### PR TITLE
various bugfixes around tag processing

### DIFF
--- a/synse_server/__init__.py
+++ b/synse_server/__init__.py
@@ -3,7 +3,7 @@ and virtual devices.
 """
 
 __title__ = 'synse_server'
-__version__ = '3.0.0-alpha.12'
+__version__ = '3.0.0-alpha.13'
 __api_version__ = 'v3'
 __description__ = 'An API to monitor and control physical and virtual devices.'
 __author__ = 'Vapor IO'

--- a/synse_server/api/http.py
+++ b/synse_server/api/http.py
@@ -238,7 +238,7 @@ async def tags(request: Request) -> HTTPResponse:
 
     return utils.http_json_response(
         await cmd.tags(
-            *namespaces,
+            namespaces,
             with_id_tags=include_ids,
         ),
     )

--- a/synse_server/api/websocket.py
+++ b/synse_server/api/websocket.py
@@ -205,7 +205,7 @@ class MessageHandler:
             logger.info(_('websocket request cancelled'), handler=handler)
             return
         except Exception as e:
-            logger.error(_('error processing websocket request'), err=e)
+            logger.exception(_('error processing websocket request'), err=e)
             await self.send(**error(
                 msg_id=payload.id,
                 ex=e,
@@ -329,7 +329,7 @@ class MessageHandler:
         await self.send(
             id=payload.id,
             event='response/tags',
-            data=await cmd.tags(*ns, with_id_tags=ids),
+            data=await cmd.tags(ns, with_id_tags=ids),
         )
 
     async def handle_request_info(self, payload: Payload) -> None:

--- a/synse_server/cmd/tags.py
+++ b/synse_server/cmd/tags.py
@@ -6,7 +6,7 @@ from synse_server.i18n import _
 from synse_server.log import logger
 
 
-async def tags(*namespaces: str, with_id_tags: bool = False) -> List[str]:
+async def tags(namespaces: List[str], with_id_tags: bool = False) -> List[str]:
     """Generate the tags response data.
 
     Args:

--- a/tests/unit/api/test_http.py
+++ b/tests/unit/api/test_http.py
@@ -677,6 +677,7 @@ class TestV3Tags:
 
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
+            [],
             with_id_tags=False,
         )
 
@@ -698,6 +699,7 @@ class TestV3Tags:
 
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
+            [],
             with_id_tags=False
         )
 
@@ -731,7 +733,7 @@ class TestV3Tags:
 
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
-            *expected,
+            expected,
             with_id_tags=False,
         )
 
@@ -773,6 +775,7 @@ class TestV3Tags:
 
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
+            [],
             with_id_tags=expected,
         )
 

--- a/tests/unit/api/test_websocket.py
+++ b/tests/unit/api/test_websocket.py
@@ -487,6 +487,7 @@ class TestMessageHandler:
 
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
+            [],
             with_id_tags=False,
         )
         mock_send.assert_called_once()
@@ -511,7 +512,7 @@ class TestMessageHandler:
 
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
-            'a', 'b', 'c',
+            ['a', 'b', 'c'],
             with_id_tags=False,
         )
         mock_send.assert_called_once()
@@ -536,6 +537,7 @@ class TestMessageHandler:
 
         mock_cmd.assert_called_once()
         mock_cmd.assert_called_with(
+            [],
             with_id_tags=True,
         )
         mock_send.assert_called_once()

--- a/tests/unit/cmd/test_read.py
+++ b/tests/unit/cmd/test_read.py
@@ -243,6 +243,52 @@ async def test_read_ok_tags_without_ns(mocker, simple_plugin, state_reading):
 
 
 @pytest.mark.asyncio
+async def test_read_ok_single_tag_group_without_ns(mocker, simple_plugin, state_reading):
+    # Mock test data
+    mocker.patch.dict('synse_server.plugin.PluginManager.plugins', {
+        '123': simple_plugin,
+        '456': simple_plugin,
+    })
+
+    mock_read = mocker.patch(
+        'synse_grpc.client.PluginClientV3.read',
+        return_value=[
+            state_reading,
+        ],
+    )
+
+    # --- Test case -----------------------------
+    # Set the simple_plugin to active to start.
+    simple_plugin.active = True
+
+    resp = await cmd.read('default', ['foo', 'bar', 'vapor/ware'])
+
+    # Note: There are two plugins defined, so we should expect each
+    # plugin to return a reading. Since the fixture returns the same reading
+    # at the same timestamp, we take this to be the same reading and deduplicate
+    # it, hence we only get one reading here.
+    assert resp == [
+        {  # from state_reading fixture
+            'device': 'ccc',
+            'timestamp': '2019-04-22T13:30:00Z',
+            'type': 'state',
+            'device_type': 'led',
+            'value': 'on',
+            'unit': None,
+            'context': {},
+        },
+    ]
+
+    assert simple_plugin.active is True
+
+    mock_read.assert_called()
+    mock_read.assert_has_calls([
+        mocker.call(tags=['default/foo', 'default/bar', 'vapor/ware']),
+        mocker.call(tags=['default/foo', 'default/bar', 'vapor/ware']),
+    ])
+
+
+@pytest.mark.asyncio
 async def test_read_device_not_found():
     with asynctest.patch('synse_server.cache.get_plugin') as mock_get:
         mock_get.return_value = None

--- a/tests/unit/cmd/test_tags.py
+++ b/tests/unit/cmd/test_tags.py
@@ -14,7 +14,7 @@ async def test_tags_failed_get_cached_tags(mocker):
 
     # --- Test case -----------------------------
     with pytest.raises(ValueError):
-        await cmd.tags('default')
+        await cmd.tags(['default'])
 
     mock_get.assert_called_once()
 
@@ -40,7 +40,7 @@ async def test_tags_matches_tag_with_single_ns(mocker):
     )
 
     # --- Test case -----------------------------
-    resp = await cmd.tags('default')
+    resp = await cmd.tags(['default'])
     assert resp == [
         'annotation:bar',
         'default/annotation:bar',
@@ -72,7 +72,7 @@ async def test_tags_matches_tag_with_multiple_ns(mocker):
     )
 
     # --- Test case -----------------------------
-    resp = await cmd.tags('default', 'test')
+    resp = await cmd.tags(['default', 'test'])
     assert resp == [
         'annotation:bar',
         'default/annotation:bar',
@@ -106,7 +106,7 @@ async def test_tags_matches_tag_no_ns(mocker):
     )
 
     # --- Test case -----------------------------
-    resp = await cmd.tags()
+    resp = await cmd.tags([])
     assert resp == [
         'annotation:bar',
         'default/annotation:bar',
@@ -142,7 +142,7 @@ async def test_tags_with_id_tags_all_tags_matching_ns(mocker):
     )
 
     # --- Test case -----------------------------
-    resp = await cmd.tags(with_id_tags=True)
+    resp = await cmd.tags([], with_id_tags=True)
     assert resp == [
         'annotation:bar',
         'default/annotation:bar',
@@ -181,7 +181,7 @@ async def test_tags_with_id_tags_some_tags_matching_ns(mocker):
     )
 
     # --- Test case -----------------------------
-    resp = await cmd.tags('default', 'system', with_id_tags=True)
+    resp = await cmd.tags(['default', 'system'], with_id_tags=True)
     assert resp == [
         'annotation:bar',
         'default/annotation:bar',
@@ -217,7 +217,7 @@ async def test_tags_with_id_tags_no_tags_matching_ns(mocker):
     )
 
     # --- Test case -----------------------------
-    resp = await cmd.tags('no-such-namespace', with_id_tags=True)
+    resp = await cmd.tags(['no-such-namespace'], with_id_tags=True)
     assert resp == []
 
     mock_get.assert_called_once()


### PR DESCRIPTION
This PR:
- fixes a bug around user-specified namespaces for the tags request. in the event that only a single namespace is specified and not wrapped in a list, the tag processing would fail on namespace matching due to a string also being iterable (e.g. the algorithm iterated over the string characters instead of the expected strings in a list)
- fixes a bug in the read command around how tags are passed along to the command handler. with the introduction of tag groups, the number of valid tag formats include:
    * a single string (a single tag)
    * a list of strings (one tag group, multiple tags)
    * a list of list of strings (multiple tag groups)
the bug affected the second format, above, because the tags input was not normalized prior to processing, so the algorithm tried to iterate over a string instead of a list of string.
- updated / added tests
- bump to 3.0.0-alpha.13