### PR TITLE
bugfix: already registered plugin was not being set to active on refresh

### DIFF
--- a/synse_server/plugin.py
+++ b/synse_server/plugin.py
@@ -1,7 +1,7 @@
 """Management and access logic for configured plugin backends."""
 
 import time
-from typing import List, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 from synse_grpc import client, utils
 
@@ -21,7 +21,7 @@ class PluginManager:
     snapshot of currently registered plugins.
     """
 
-    plugins = {}
+    plugins: Dict[str, 'Plugin'] = {}
 
     def __iter__(self) -> 'PluginManager':
         self._snapshot = list(self.plugins.values())
@@ -109,7 +109,7 @@ class PluginManager:
             self.plugins[plugin.id] = plugin
             logger.info(_('successfully registered plugin'), id=plugin.id, tag=plugin.tag)
 
-        plugin.mark_active()
+        self.plugins[plugin.id].mark_active()
         return plugin.id
 
     @classmethod

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -152,7 +152,11 @@ class TestPluginManager:
         # --- Test case -----------------------------
         m = plugin.PluginManager()
         m.plugins = {
-            '123': 'placeholder',
+            '123': plugin.Plugin(
+                {'id': 'foo', 'tag': 'foo'},
+                {},
+                client.PluginClientV3('foo', 'tcp'),
+            ),
         }
 
         plugin_id = m.register('localhost:5432', 'tcp')


### PR DESCRIPTION
This PR:
- fixes a bug where plugin refresh wasn't marking already registered plugins as active if they became reachable again
- adds a type hint
- updates a test

fixes #351 