### PR TITLE
add a request ID for all logs generated during request handling

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -12,8 +12,8 @@ chardet==3.0.4            # via aiohttp
 coverage==5.0.3           # via pytest-cov
 idna-ssl==1.1.0           # via aiohttp
 idna==2.8                 # via idna-ssl, yarl
-importlib-metadata==1.4.0  # via pluggy, pytest
-more-itertools==8.1.0     # via pytest
+importlib-metadata==1.5.0  # via pluggy, pytest
+more-itertools==8.2.0     # via pytest
 multidict==4.7.4          # via aiohttp, yarl
 packaging==20.1           # via pytest
 pluggy==0.13.1            # via pytest
@@ -22,7 +22,7 @@ pyparsing==2.4.6          # via packaging
 pytest-asyncio==0.10.0
 pytest-cov==2.8.1
 pytest-mock==2.0.0
-pytest==5.3.4
+pytest==5.3.5
 six==1.14.0               # via packaging
 typing-extensions==3.7.4.1  # via aiohttp
 wcwidth==0.1.8            # via pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ grpcio==1.26.0
 h11==0.8.1                # via httpx
 h2==3.1.1                 # via httpx
 hpack==3.0.0              # via h2
-hstspreload==2020.1.22    # via httpx
+hstspreload==2020.1.30    # via httpx
 httptools==0.0.13         # via sanic
 httpx==0.9.3              # via sanic
 hyperframe==5.2.0         # via h2
@@ -36,6 +36,7 @@ requests==2.22.0          # via kubernetes, requests-oauthlib
 rfc3986==1.3.2            # via httpx
 rsa==4.0                  # via google-auth
 sanic==19.12.2
+shortuuid==0.5.0
 six==1.14.0               # via google-auth, grpcio, kubernetes, protobuf, python-dateutil, structlog, websocket-client
 sniffio==1.1.0            # via httpx
 structlog==20.1.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(
         'pyyaml>=4.2b1',
         'sanic>=0.8.0',
         'prometheus-client',
-        'structlog',
+        'shortuuid',
+        'structlog>=20.1.0',
         'websockets',
         'synse-grpc==3.0.0a4',  # fixme: for alpha v3 testing; update to stable v3 release
     ],

--- a/synse_server/app.py
+++ b/synse_server/app.py
@@ -1,9 +1,16 @@
 """Factory for creating Synse Server Sanic application instances."""
 
+import shortuuid
+import structlog
 from sanic import Sanic
+from sanic.request import Request
+from sanic.response import HTTPResponse
+from structlog import contextvars
 
 from synse_server import errors
 from synse_server.api import http, websocket
+
+logger = structlog.get_logger()
 
 
 def new_app() -> Sanic:
@@ -31,4 +38,29 @@ def new_app() -> Sanic:
     # a browser hits an endpoint and can't find the icon.
     app.static('/favicon.ico', '/etc/synse/static/favicon.ico')
 
+    # Register middleware with the application.
+    app.register_middleware(on_request, 'request')
+    app.register_middleware(on_response, 'response')
+
     return app
+
+
+def on_request(request: Request) -> None:
+    """Middleware function that runs prior to processing a request via Sanic."""
+    # Generate a unique request ID and use it as a field in any logging that
+    # takes place during the request handling.
+    req_id = shortuuid.uuid()
+    request.ctx.uuid = req_id
+
+    contextvars.clear_contextvars()
+    contextvars.bind_contextvars(
+        request_id=req_id,
+    )
+
+
+def on_response(request: Request, response: HTTPResponse) -> None:
+    """Middleware function that runs prior to returning a response via Sanic."""
+    # Unbind the request ID from the logger.
+    contextvars.unbind_contextvars(
+        'request_id',
+    )

--- a/synse_server/log.py
+++ b/synse_server/log.py
@@ -6,6 +6,7 @@ import sys
 
 import structlog
 from sanic import app, asgi, handlers, request, server
+from structlog import contextvars
 
 from synse_server import config
 
@@ -55,6 +56,7 @@ logging.config.dictConfig(logging_config)
 
 structlog.configure(
     processors=[
+        contextvars.merge_contextvars,
         structlog.stdlib.filter_by_level,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,


### PR DESCRIPTION
This PR:
- adds a request ID within the context of a request being processed, so all logs  generated for the request will have the request ID associated with them, making it easier to tie log events to specific requests. this can be expanded upon in the future.

Example:
```
timestamp='2020-01-30T13:29:31.096917Z' logger='synse_server.api.http' level='debug' event='processing request' request_id='wfYy33jjFexsVFRbLjV7zj' method='GET' ip='172.18.0.1' path='/v3/plugin'
timestamp='2020-01-30T13:29:31.097165Z' logger='synse_server.cmd.plugin' level='info' event='issuing command' request_id='wfYy33jjFexsVFRbLjV7zj' command='PLUGINS'
timestamp='2020-01-30T13:29:31.097775Z' logger='sanic.access' level='info' event='' extra={'status': 200, 'byte': 236, 'host': '172.18.0.1:52010', 'request': 'GET http://localhost:5000/v3/plugin'}
timestamp='2020-01-30T13:29:35.008360Z' logger='synse_server.api.http' level='debug' event='processing request' request_id='nDs6XFxtGqR8ZsNCykj4MV' method='GET' ip='172.18.0.1' path='/v3/plugin'
timestamp='2020-01-30T13:29:35.008599Z' logger='synse_server.cmd.plugin' level='info' event='issuing command' request_id='nDs6XFxtGqR8ZsNCykj4MV' command='PLUGINS'
timestamp='2020-01-30T13:29:35.008946Z' logger='sanic.access' level='info' event='' extra={'status': 200, 'byte': 236, 'host': '172.18.0.1:52014', 'request': 'GET http://localhost:5000/v3/plugin'}
timestamp='2020-01-30T13:29:36.200119Z' logger='synse_server.api.http' level='debug' event='processing request' request_id='gGRM5xP8HZBP2cB9wUyBFL' method='GET' ip='172.18.0.1' path='/v3/plugin'
timestamp='2020-01-30T13:29:36.200417Z' logger='synse_server.cmd.plugin' level='info' event='issuing command' request_id='gGRM5xP8HZBP2cB9wUyBFL' command='PLUGINS'
timestamp='2020-01-30T13:29:36.200786Z' logger='sanic.access' level='info' event='' extra={'status': 200, 'byte': 236, 'host': '172.18.0.1:52018', 'request': 'GET http://localhost:5000/v3/plugin'}
timestamp='2020-01-30T13:30:04.919274Z' logger='synse_server.api.http' level='debug' event='processing request' request_id='jx5568Jw5kyjv4YaZaKUYM' method='GET' ip='127.0.0.1' path='/test'
timestamp='2020-01-30T13:30:04.919471Z' logger='synse_server.cmd.test' level='info' event='issuing command' request_id='jx5568Jw5kyjv4YaZaKUYM' command='TEST'
timestamp='2020-01-30T13:30:04.920018Z' logger='sanic.access' level='info' event='' extra={'status': 200, 'byte': 58, 'host': '127.0.0.1:49230', 'request': 'GET http://localhost:5000/test'}
timestamp='2020-01-30T13:31:04.979576Z' logger='synse_server.api.http' level='debug' event='processing request' request_id='NzR6DLN6oMhjr6TJ4njNPZ' method='GET' ip='127.0.0.1' path='/test'
timestamp='2020-01-30T13:31:04.979752Z' logger='synse_server.cmd.test' level='info' event='issuing command' request_id='NzR6DLN6oMhjr6TJ4njNPZ' command='TEST'
timestamp='2020-01-30T13:31:04.980202Z' logger='sanic.access' level='info' event='' extra={'status': 200, 'byte': 58, 'host': '127.0.0.1:49232', 'request': 'GET http://localhost:5000/test'}
timestamp='2020-01-30T13:31:05.784241Z' logger='synse_server.tasks' level='info' event='task: refreshing plugins' task='periodic plugin refresh' interval=120
timestamp='2020-01-30T13:31:05.784540Z' logger='synse_server.plugin' level='debug' event='refreshing plugin manager'
timestamp='2020-01-30T13:31:05.784767Z' logger='synse_server.plugin' level='info' event='loading plugins from configuration'

```

Note the `request_id` field in some of the messages.