### PR TITLE
feat: make plugin refresh interval configurable

### DIFF
--- a/synse_server/config.py
+++ b/synse_server/config.py
@@ -21,10 +21,13 @@ scheme = Scheme(
     )),
     DictOption('cache', default=None, scheme=Scheme(
         DictOption('device', scheme=Scheme(
-            Option('rebuild_every', default=180, field_type=int)  # three minutes
+            Option('rebuild_every', default=180, field_type=int),  # three minutes
+        )),
+        DictOption('plugin', scheme=Scheme(
+            Option('refresh_every', default=120, field_type=int),  # two minutes
         )),
         DictOption('transaction', scheme=Scheme(
-            Option('ttl', default=300, field_type=int)  # five minutes
+            Option('ttl', default=300, field_type=int),  # five minutes
         ))
     )),
     DictOption('grpc', scheme=Scheme(

--- a/synse_server/tasks.py
+++ b/synse_server/tasks.py
@@ -48,7 +48,7 @@ async def _rebuild_device_cache() -> None:
 
 async def _refresh_plugins() -> None:
     """Periodically refresh the plugin manager."""
-    interval = 2 * 60  # 2 minutes
+    interval = config.options.get('cache.plugin.refresh_every', 2 * 60)  # 2 minute default
 
     while True:
         logger.info(


### PR DESCRIPTION
This PR:
- makes the interval for the plugin refresh task configurable

fixes #358 