### PR TITLE
V3/refresh on cache rebuild

### DIFF
--- a/synse_server/cache.py
+++ b/synse_server/cache.py
@@ -147,11 +147,12 @@ async def update_device_cache() -> None:
     # each registered plugin. This device data will be used to generate
     # the cache.
     #
-    # If there are no plugins currently registered, attempt
-    # to re-register. This can be the case when Synse Server is first
-    # starting up, being restarted, or is recovering from a networking error.
-    if len(plugin.manager.plugins) == 0:
-        logger.debug(_('no plugins found when updating device cache'))
+    # If there are no plugins currently registered, or any plugin is currently
+    # marked inactive, attempt to refresh all plugins. This can be the case when
+    # Synse Server is first starting up, being restarted, or is recovering from a
+    # networking error.
+    if not plugin.manager.has_plugins() or not plugin.manager.all_active():
+        logger.debug(_('refreshing plugins prior to updating device cache'))
         plugin.manager.refresh()
 
     async with device_cache_lock:

--- a/synse_server/plugin.py
+++ b/synse_server/plugin.py
@@ -216,6 +216,15 @@ class PluginManager:
             elapsed_time=time.time() - start,
         )
 
+    def all_active(self) -> bool:
+        """Check to see if all registered plugins are active.
+
+        If a single plugin is inactive, this returns False. If no plugins are
+        registered, this returns True. In such a case, it is up to the caller to
+        perform additional checks for number of registered plugins.
+        """
+        return all(plugin.active for plugin in self)
+
 
 # A module-level instance of the plugin manager. This makes it easier to use
 # the manager in various places, without having to initialize a new instance.

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -74,6 +74,46 @@ class TestPluginManager:
         assert result is not None
         assert result == 'placeholder'
 
+    def test_all_active_true_no_plugins(self):
+        m = plugin.PluginManager()
+        assert m.all_active() is True
+
+    def test_all_active_true_has_plugins(self):
+        p1 = plugin.Plugin({'id': '1', 'tag': 'foo'}, {}, client.PluginClientV3('foo', 'tcp'))
+        p2 = plugin.Plugin({'id': '2', 'tag': 'foo'}, {}, client.PluginClientV3('foo', 'tcp'))
+        p3 = plugin.Plugin({'id': '3', 'tag': 'foo'}, {}, client.PluginClientV3('foo', 'tcp'))
+
+        p1.mark_active()
+        p2.mark_active()
+        p3.mark_active()
+
+        m = plugin.PluginManager()
+        m.plugins = {
+            '1': p1,
+            '2': p2,
+            '3': p3,
+        }
+
+        assert m.all_active() is True
+
+    def test_all_active_false_has_plugins(self):
+        p1 = plugin.Plugin({'id': '1', 'tag': 'foo'}, {}, client.PluginClientV3('foo', 'tcp'))
+        p2 = plugin.Plugin({'id': '2', 'tag': 'foo'}, {}, client.PluginClientV3('foo', 'tcp'))
+        p3 = plugin.Plugin({'id': '3', 'tag': 'foo'}, {}, client.PluginClientV3('foo', 'tcp'))
+
+        p1.mark_active()
+        p2.mark_inactive()
+        p3.mark_active()
+
+        m = plugin.PluginManager()
+        m.plugins = {
+            '1': p1,
+            '2': p2,
+            '3': p3,
+        }
+
+        assert m.all_active() is False
+
     def test_register_fail_metadata_call(self, mocker):
         # Mock test data
         mock_metadata = mocker.patch(


### PR DESCRIPTION
This PR:
- adds a plugin manager util to check if all registered plugins are active
- updates device cache rebuild to refresh plugins if not all are active. this fixes a bug where a plugin being restarted may not show up in a device scan despite being marked active, since it may be marked active after the cache rebuild ran

This should resolve #357 