### PR TITLE
bugfix: fix issues with txn cache ttl being set as well as rebuild clearing the cache

### DIFF
--- a/synse_server/server.py
+++ b/synse_server/server.py
@@ -11,7 +11,7 @@ import sys
 from structlog import get_logger
 
 import synse_server
-from synse_server import app, config, loop, metrics, plugin, tasks
+from synse_server import app, cache, config, loop, metrics, plugin, tasks
 from synse_server.i18n import _
 from synse_server.log import setup_logger
 
@@ -112,6 +112,9 @@ class Synse:
             _('created server directories on filesystem'),
             dirs=(self._server_config_dir, self._socket_dir),
         )
+
+        # Configure caches
+        cache.transaction_cache.ttl = config.options.get('cache.transaction.ttl', None)
 
     def run(self) -> None:
         """Run Synse Server."""


### PR DESCRIPTION
This PR:
- fixes a bug where the transaction cache ttl wasn't being correctly set because of an order of operations bug where config was not loaded in yet
- fixes a bug where calling `clear` on any of the caches would clear the entire backing cache for all caches, regardless of namespace. this was causing transactions to be invalidated on device cache rebuild.

fixes #363 