### PR TITLE
feat: update docker image to py38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # BUILDER STAGE
 #
-FROM vaporio/python:3.6 as builder
+FROM vaporio/python:3.8 as builder
 
 COPY requirements.txt .
 
@@ -15,7 +15,7 @@ RUN pip install --no-deps --prefix=/build --no-warn-script-location /synse \
 #
 # RELEASE STAGE
 #
-FROM vaporio/python:3.6-slim
+FROM vaporio/python:3.8-slim
 
 LABEL maintainer="Vapor IO" \
       name="vaporio/synse-server" \

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py3
 
 
 [testenv]


### PR DESCRIPTION
This PR:
- bumps the docker image from py3.6 to py3.8
-  loosens restrictions on the tox env so it can run 3.8 as well