### PR TITLE
feat: update request/reponse logging, disable sanic access log

### DIFF
--- a/synse_server/api/http.py
+++ b/synse_server/api/http.py
@@ -17,22 +17,6 @@ core = Blueprint('core-http')
 v3 = Blueprint('v3-http', version='v3')
 
 
-def log_request(request, **kwargs):
-    """Log information about the incoming request.
-
-    Args:
-        request: The incoming request.
-        kwargs: Any additional fields to add to the structured logs.
-    """
-    logger.debug(
-        'processing request',
-        method=request.method,
-        ip=request.ip,
-        path=request.path,
-        **kwargs,
-    )
-
-
 @core.route('/test')
 async def test(request: Request) -> HTTPResponse:
     """A dependency and side-effect free check to see whether Synse Server
@@ -46,8 +30,6 @@ async def test(request: Request) -> HTTPResponse:
         * 200: OK
         * 500: Catchall processing error
     """
-    log_request(request)
-
     return utils.http_json_response(
         await cmd.test(),
     )
@@ -64,8 +46,6 @@ async def version(request: Request) -> HTTPResponse:
         * 200: OK
         * 500: Catchall processing error
     """
-    log_request(request)
-
     try:
         return utils.http_json_response(
             await cmd.version(),
@@ -88,8 +68,6 @@ async def config(request: Request) -> HTTPResponse:
         * 200: OK
         * 500: Catchall processing error
     """
-    log_request(request)
-
     try:
         return utils.http_json_response(
             await cmd.config(),
@@ -107,8 +85,6 @@ async def plugins(request: Request) -> HTTPResponse:
         * 200: OK
         * 500: Catchall processing error
     """
-    log_request(request)
-
     refresh = request.args.get('refresh', 'false').lower() == 'true'
 
     try:
@@ -134,8 +110,6 @@ async def plugin(request: Request, plugin_id: str) -> HTTPResponse:
         * 404: Plugin not found
         * 500: Catchall processing error
     """
-    log_request(request, id=plugin_id)
-
     try:
         return utils.http_json_response(
             await cmd.plugin(plugin_id),
@@ -153,8 +127,6 @@ async def plugin_health(request: Request) -> HTTPResponse:
         * 200: OK
         * 500: Catchall processing error
     """
-    log_request(request)
-
     try:
         return utils.http_json_response(
             await cmd.plugin_health(),
@@ -194,8 +166,6 @@ async def scan(request: Request) -> HTTPResponse:
         * 400: Invalid parameter(s)
         * 500: Catchall processing error
     """
-    log_request(request, params=request.args)
-
     namespace = 'default'
     param_ns = request.args.getlist('ns')
     if param_ns:
@@ -255,8 +225,6 @@ async def tags(request: Request) -> HTTPResponse:
         * 200: OK
         * 500: Catchall processing error
     """
-    log_request(request, params=request.args)
-
     namespaces = []
     param_ns = request.args.getlist('ns')
     if param_ns:
@@ -289,8 +257,6 @@ async def info(request: Request, device_id: str) -> HTTPResponse:
         * 404: Device not found
         * 500: Catchall processing error
     """
-    log_request(request, id=device_id)
-
     try:
         return utils.http_json_response(
             await cmd.info(device_id),
@@ -322,8 +288,6 @@ async def read(request: Request) -> HTTPResponse:
         * 400: Invalid parameter(s)
         * 500: Catchall processing error
     """
-    log_request(request, params=request.args)
-
     namespace = 'default'
     param_ns = request.args.getlist('ns')
     if param_ns:
@@ -370,8 +334,6 @@ async def read_cache(request: Request) -> StreamingHTTPResponse:
         * 400: Invalid query parameter(s)
         * 500: Catchall processing error
     """
-    log_request(request, params=request.args)
-
     start = ''
     param_start = request.args.getlist('start')
     if param_start:
@@ -422,8 +384,6 @@ async def read_device(request: Request, device_id: str) -> HTTPResponse:
         * 405: Device does not support reading
         * 500: Catchall processing error
     """
-    log_request(request, id=device_id)
-
     try:
         return utils.http_json_response(
             await cmd.read_device(device_id),
@@ -451,7 +411,7 @@ async def async_write(request: Request, device_id: str) -> HTTPResponse:
         * 405: Device does not support writing
         * 500: Catchall processing error
     """
-    log_request(request, id=device_id, payload=request.body)
+    logger.debug('parsing request body', payload=request.body)
 
     try:
         data = request.json
@@ -500,7 +460,7 @@ async def sync_write(request: Request, device_id: str) -> HTTPResponse:
         * 405: Device does not support writing
         * 500: Catchall processing error
     """
-    log_request(request, id=device_id, payload=request.body)
+    logger.debug('parsing request body', payload=request.body)
 
     try:
         data = request.json
@@ -539,8 +499,6 @@ async def transactions(request: Request) -> HTTPResponse:
         * 200: OK
         * 500: Catchall processing error
     """
-    log_request(request)
-
     try:
         return utils.http_json_response(
             await cmd.transactions(),
@@ -562,8 +520,6 @@ async def transaction(request: Request, transaction_id: str) -> HTTPResponse:
         * 404: Transaction not found
         * 500: Catchall processing error
     """
-    log_request(request, id=transaction_id)
-
     try:
         return utils.http_json_response(
             await cmd.transaction(transaction_id),
@@ -591,8 +547,6 @@ async def device(request: Request, device_id: str) -> HTTPResponse:
         * 405: Device does not support reading/writing
         * 500: Catchall processing error
     """
-    log_request(request, id=device_id)
-
     if request.method == 'GET':
         return await read_device(request, device_id)
 

--- a/synse_server/app.py
+++ b/synse_server/app.py
@@ -57,9 +57,26 @@ def on_request(request: Request) -> None:
         request_id=req_id,
     )
 
+    logger.debug(
+        'processing HTTP request',
+        method=request.method,
+        ip=request.ip,
+        path=request.path,
+        headers=dict(request.headers),
+        args=request.args,
+    )
+
 
 def on_response(request: Request, response: HTTPResponse) -> None:
     """Middleware function that runs prior to returning a response via Sanic."""
+
+    logger.debug(
+        'returning HTTP response',
+        request=f'{request.method} {request.url}',
+        status=response.status,
+        bytes=len(response.body),
+    )
+
     # Unbind the request ID from the logger.
     contextvars.unbind_contextvars(
         'request_id',

--- a/synse_server/log.py
+++ b/synse_server/log.py
@@ -33,12 +33,6 @@ logging_config = {
             'propagate': True,
             'qualname': 'sanic.error',
         },
-        'sanic.access': {
-            'level': 'INFO',
-            'handlers': ['default'],
-            'propagate': True,
-            'qualname': 'sanic.access',
-        },
     },
     'handlers': {
         'default': {
@@ -83,7 +77,6 @@ def override_sanic_loggers():
     # so we are stuck with just replacing those references in their
     # respective modules.
     root = structlog.get_logger('sanic.root')
-    access = structlog.get_logger('sanic.access')
     error = structlog.get_logger('sanic.error')
 
     app.error_logger = error
@@ -93,7 +86,6 @@ def override_sanic_loggers():
     request.logger = root
     request.error_logger = error
     server.logger = root
-    server.access_logger = access
 
 
 override_sanic_loggers()

--- a/synse_server/server.py
+++ b/synse_server/server.py
@@ -155,6 +155,7 @@ class Synse:
             port=self.port,
             ssl=ssl_context,
             return_asyncio_server=True,
+            access_log=False,
         )
         asyncio.ensure_future(self.server, loop=loop.synse_loop)
         loop.synse_loop.run_forever()


### PR DESCRIPTION
This PR:
- disables the sanic access log, as it doesn't format messages well for structlog
- moves the existing request logging to app middleware
- adds response logging

Example logs of this new setup:
```
timestamp='2020-03-02T14:36:46.096092Z' logger='synse_server.app' level='debug' event='processing HTTP request' request_id='ZEXhnBYZr74w67mRgTXmxj' method='GET' ip='192.168.112.1' path='/test' headers={'host': 'localhost:5000', 'user-agent': 'curl/7.64.1', 'accept': '*/*'} args={}
timestamp='2020-03-02T14:36:46.096360Z' logger='synse_server.cmd.test' level='info' event='issuing command' request_id='ZEXhnBYZr74w67mRgTXmxj' command='TEST'
timestamp='2020-03-02T14:36:46.096907Z' logger='synse_server.app' level='debug' event='returning HTTP response' request_id='ZEXhnBYZr74w67mRgTXmxj' request='GET http://localhost:5000/test' status=200 bytes=58
```