### PR TITLE
feat: update to plugin reconnect mechanics

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -20,12 +20,16 @@ pipeline {
     }
 
     stage('Test') {
+      agent {
+        label 'python-3.8'
+      }
       environment {
         CODECOV_TOKEN = credentials('codecov-token')
       }
       steps {
-        sh 'tox tests/unit'
-        sh 'codecov'
+        container('python') {
+          sh 'tox tests/unit'
+        }
       }
     }
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,27 +4,24 @@
 #
 #    pip-compile --output-file=requirements-test.txt test-requirements.in
 #
-aiohttp==3.6.2
+aiohttp==3.6.2            # via -r test-requirements.in
 async-timeout==3.0.1      # via aiohttp
-asynctest==0.13.0
+asynctest==0.13.0         # via -r test-requirements.in
 attrs==19.3.0             # via aiohttp, pytest
 chardet==3.0.4            # via aiohttp
 coverage==5.0.3           # via pytest-cov
-idna-ssl==1.1.0           # via aiohttp
-idna==2.9                 # via idna-ssl, yarl
-importlib-metadata==1.5.0  # via pluggy, pytest
+idna==2.9                 # via yarl
+mock==4.0.1               # via -r test-requirements.in
 more-itertools==8.2.0     # via pytest
-multidict==4.7.4          # via aiohttp, yarl
-packaging==20.1           # via pytest
+multidict==4.7.5          # via aiohttp, yarl
+packaging==20.3           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pyparsing==2.4.6          # via packaging
-pytest-asyncio==0.10.0
-pytest-cov==2.8.1
-pytest-mock==2.0.0
-pytest==5.3.5
+pytest-asyncio==0.10.0    # via -r test-requirements.in
+pytest-cov==2.8.1         # via -r test-requirements.in
+pytest-mock==2.0.0        # via -r test-requirements.in
+pytest==5.3.5             # via -r test-requirements.in, pytest-asyncio, pytest-cov, pytest-mock
 six==1.14.0               # via packaging
-typing-extensions==3.7.4.1  # via aiohttp
 wcwidth==0.1.8            # via pytest
 yarl==1.4.2               # via aiohttp
-zipp==3.0.0               # via importlib-metadata

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,7 +10,9 @@ asynctest==0.13.0         # via -r test-requirements.in
 attrs==19.3.0             # via aiohttp, pytest
 chardet==3.0.4            # via aiohttp
 coverage==5.0.3           # via pytest-cov
-idna==2.9                 # via yarl
+idna-ssl==1.1.0           # via aiohttp
+idna==2.9                 # via idna-ssl, yarl
+importlib-metadata==1.5.0  # via pluggy, pytest
 mock==4.0.1               # via -r test-requirements.in
 more-itertools==8.2.0     # via pytest
 multidict==4.7.5          # via aiohttp, yarl
@@ -23,5 +25,7 @@ pytest-cov==2.8.1         # via -r test-requirements.in
 pytest-mock==2.0.0        # via -r test-requirements.in
 pytest==5.3.5             # via -r test-requirements.in, pytest-asyncio, pytest-cov, pytest-mock
 six==1.14.0               # via packaging
+typing-extensions==3.7.4.1  # via aiohttp
 wcwidth==0.1.8            # via pytest
 yarl==1.4.2               # via aiohttp
+zipp==3.1.0               # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ bison==0.1.2              # via synse_server (setup.py)
 cachetools==4.0.0         # via google-auth
 certifi==2019.11.28       # via httpx, kubernetes, requests
 chardet==3.0.4            # via httpx, requests
+contextvars==2.4          # via sniffio
 google-auth==1.11.2       # via kubernetes
 grpcio==1.27.2            # via synse-grpc, synse_server (setup.py)
 h11==0.8.1                # via httpx
@@ -20,6 +21,7 @@ httptools==0.1.1          # via sanic
 httpx==0.9.3              # via sanic
 hyperframe==5.2.0         # via h2
 idna==2.9                 # via httpx, requests
+immutables==0.11          # via contextvars
 kubernetes==10.0.1        # via synse_server (setup.py)
 multidict==4.7.5          # via sanic
 oauthlib==3.1.0           # via requests-oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,48 +4,46 @@
 #
 #    pip-compile --output-file=requirements.txt setup.py
 #
-aiocache==0.11.1
+aiocache==0.11.1          # via synse_server (setup.py)
 aiofiles==0.4.0           # via sanic
-bison==0.1.2
+bison==0.1.2              # via synse_server (setup.py)
 cachetools==4.0.0         # via google-auth
 certifi==2019.11.28       # via httpx, kubernetes, requests
 chardet==3.0.4            # via httpx, requests
-contextvars==2.4          # via sniffio
 google-auth==1.11.2       # via kubernetes
-grpcio==1.27.2
+grpcio==1.27.2            # via synse-grpc, synse_server (setup.py)
 h11==0.8.1                # via httpx
 h2==3.2.0                 # via httpx
 hpack==3.0.0              # via h2
-hstspreload==2020.2.20    # via httpx
+hstspreload==2020.3.4     # via httpx
 httptools==0.1.1          # via sanic
 httpx==0.9.3              # via sanic
 hyperframe==5.2.0         # via h2
 idna==2.9                 # via httpx, requests
-immutables==0.11          # via contextvars
-kubernetes==10.0.1
-multidict==4.7.4          # via sanic
+kubernetes==10.0.1        # via synse_server (setup.py)
+multidict==4.7.5          # via sanic
 oauthlib==3.1.0           # via requests-oauthlib
-prometheus-client==0.7.1
+prometheus-client==0.7.1  # via synse_server (setup.py)
 protobuf==3.11.3          # via synse-grpc
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 python-dateutil==2.8.1    # via kubernetes
-pyyaml==5.3
+pyyaml==5.3               # via bison, kubernetes, synse_server (setup.py)
 requests-oauthlib==1.3.0  # via kubernetes
 requests==2.23.0          # via kubernetes, requests-oauthlib
 rfc3986==1.3.2            # via httpx
 rsa==4.0                  # via google-auth
-sanic==19.12.2
-shortuuid==0.5.0
+sanic==19.12.2            # via synse_server (setup.py)
+shortuuid==0.5.1          # via synse_server (setup.py)
 six==1.14.0               # via google-auth, grpcio, kubernetes, protobuf, python-dateutil, structlog, websocket-client
 sniffio==1.1.0            # via httpx
-structlog==20.1.0
-synse-grpc==3.0.0a4
+structlog==20.1.0         # via synse_server (setup.py)
+synse-grpc==3.0.0a4       # via synse_server (setup.py)
 ujson==1.35               # via sanic
 urllib3==1.25.8           # via kubernetes, requests
 uvloop==0.14.0            # via sanic
 websocket-client==0.57.0  # via kubernetes
-websockets==8.1
+websockets==8.1           # via sanic, synse_server (setup.py)
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==45.2.0        # via google-auth, kubernetes, protobuf
+# setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,12 +34,12 @@ requests==2.23.0          # via kubernetes, requests-oauthlib
 rfc3986==1.3.2            # via httpx
 rsa==4.0                  # via google-auth
 sanic==19.12.2            # via synse_server (setup.py)
-shortuuid==0.5.1          # via synse_server (setup.py)
+shortuuid==1.0.1          # via synse_server (setup.py)
 six==1.14.0               # via google-auth, grpcio, kubernetes, protobuf, python-dateutil, structlog, websocket-client
 sniffio==1.1.0            # via httpx
 structlog==20.1.0         # via synse_server (setup.py)
 synse-grpc==3.0.0a4       # via synse_server (setup.py)
-ujson==1.35               # via sanic
+ujson==2.0.1              # via sanic
 urllib3==1.25.8           # via kubernetes, requests
 uvloop==0.14.0            # via sanic
 websocket-client==0.57.0  # via kubernetes

--- a/synse_server/backoff.py
+++ b/synse_server/backoff.py
@@ -1,0 +1,56 @@
+"""Retry backoff strategies."""
+
+import random
+import time
+from typing import Union
+
+__all__ = ['ExponentialBackoff']
+
+
+class ExponentialBackoff:
+    """An implementation of the exponential backoff strategy.
+
+    This is useful for getting an exponentially backed-off delay for
+    reconnection or retry actions.
+
+    Each call to ``delay`` will return the next exponentially backed-off
+    value, in seconds, to use for waiting. The backoff will continue for
+    each call, up to a maximum of 2^10 * base.
+
+    Args:
+        base: The base delay, in seconds. This is the starting point for
+            the returned exponentially backed off time values.
+        cap: The cap on the exponent, after which the backoff will not
+            grow exponentially. This is 9 by default (2^9 = 512 ~= 8.5 minutes)
+    """
+
+    def __init__(self, base: int = 1, cap: int = 9) -> None:
+        self._base = base
+        self._exp = 0
+        self._max = cap
+
+        self._reset_time = base * 2 ** (self._max + 1)
+        self._last_invocation = time.monotonic()
+
+        self.rand = random.Random()
+        self.rand.seed()
+
+    def delay(self) -> Union[int, float]:
+        """Get the next exponentially backed off time delay, in seconds.
+
+        The delay value is incremented exponentially with every call, up
+        to the defined max. If a period of time greater than 2^(max+1) * base
+        has passed, the backoff is reset.
+
+        Returns:
+            The time, in seconds, to be used as the next delay interval.
+        """
+        invocation = time.monotonic()
+        interval = invocation - self._last_invocation
+        self._last_invocation = invocation
+
+        if interval > self._reset_time:
+            self._exp = 0
+
+        self._exp = min(self._exp + 1, self._max)
+        return self.rand.uniform(0, self._base * 2 ** self._exp)

--- a/synse_server/cache.py
+++ b/synse_server/cache.py
@@ -149,7 +149,7 @@ async def update_device_cache() -> None:
     # marked inactive, attempt to refresh all plugins. This can be the case when
     # Synse Server is first starting up, being restarted, or is recovering from a
     # networking error.
-    if not plugin.manager.has_plugins() or not plugin.manager.all_active():
+    if not plugin.manager.has_plugins() or not plugin.manager.all_ready():
         logger.debug('refreshing plugins prior to updating device cache')
         plugin.manager.refresh()
 

--- a/synse_server/plugin.py
+++ b/synse_server/plugin.py
@@ -262,7 +262,7 @@ class PluginManager:
 
             # Disable all removed plugins and stop any active tasks they may be running.
             for plugin in removed:
-                logger.info(
+                logger.warn(
                     'registered plugin not found during refresh, marking as disabled',
                     plugin=plugin,
                 )
@@ -274,7 +274,7 @@ class PluginManager:
             for plugin in existing:
                 if plugin.disabled:
                     logger.info(
-                        'refresh found previously disable plugin; re-enabling',
+                        'refresh found previously disabled plugin; re-enabling',
                         plugin=plugin,
                     )
                     plugin.disabled = False

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,5 +1,6 @@
 aiohttp
 asynctest
+mock
 pytest
 pytest-asyncio
 pytest-cov

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 import datetime
 import logging
 
+import asynctest
 import pytest
 from synse_grpc import api, client
 
@@ -116,6 +117,7 @@ def simple_plugin():
         version={},
     )
     p.active = True
+    p._reconnect = asynctest.CoroutineMock()
     return p
 
 

--- a/tests/unit/test_backoff.py
+++ b/tests/unit/test_backoff.py
@@ -1,0 +1,35 @@
+"""Unit tests for the synse_server.backoff package."""
+
+from synse_server import backoff
+
+
+class TestExponentialBackoff:
+
+    def test_delay(self):
+        back = backoff.ExponentialBackoff()
+
+        delay_1 = back.delay()
+        delay_2 = back.delay()
+        delay_3 = back.delay()
+        delay_4 = back.delay()
+        delay_5 = back.delay()
+        delay_6 = back.delay()
+        delay_7 = back.delay()
+        delay_8 = back.delay()
+        delay_9 = back.delay()
+        delay_10 = back.delay()
+        delay_11 = back.delay()
+        delay_12 = back.delay()
+
+        assert 0 < delay_1 < 2
+        assert 0 < delay_2 < 4
+        assert 0 < delay_3 < 8
+        assert 0 < delay_4 < 16
+        assert 0 < delay_5 < 32
+        assert 0 < delay_6 < 64
+        assert 0 < delay_7 < 128
+        assert 0 < delay_8 < 256
+        assert 0 < delay_9 < 512  # hit the max, should not exceed
+        assert 0 < delay_10 < 512
+        assert 0 < delay_11 < 512
+        assert 0 < delay_12 < 512

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -54,7 +54,7 @@ def test_http_json_response_from_dict_pretty(mocker):
     actual = utils.http_json_response({'status': 'ok'})
 
     assert isinstance(actual, HTTPResponse)
-    assert actual.body == b'{\n  "status":"ok"\n}\n'
+    assert actual.body == b'{\n  "status": "ok"\n}\n'
     assert actual.status == 200
     assert actual.content_type == 'application/json'
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
 commands =
     pip-sync {toxinidir}/requirements.txt {toxinidir}/requirements-test.txt
     pytest -s \
+        --disable-warnings \
         --cov-report html \
         --cov-report term \
         --cov synse_server \


### PR DESCRIPTION
This PR:
- updates the approach for refreshing plugin active/inactive state by starting a task once a plugin is marked inactive in order to exponentially backoff retrying to re-establish connection with the plugin.
- separates a notion of "active/inactive" vs "disabled". They are closely related so the distinction may be a bit confusing
  - "active/inactive": whether the plugin can be connected to (assumes that the plugin is detected as present via config/discovery)
  - "disabled": whether the plugin is showing up on refresh (e.g. discovery)
- adds tests
- updates dependencies


fixes #371 