### PR TITLE
feat: omit an empty 'transaction' field from write/txn reflected context

### DIFF
--- a/synse_server/cmd/transaction.py
+++ b/synse_server/cmd/transaction.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 import synse_grpc.utils
 from structlog import get_logger
 
-from synse_server import cache, errors, plugin
+from synse_server import cache, errors, plugin, utils
 
 logger = get_logger()
 
@@ -54,8 +54,8 @@ async def transaction(transaction_id: str) -> Dict[str, Any]:
 
     status = synse_grpc.utils.to_dict(response)
     status['device'] = device
-    if status.get('context', {}).get('data'):
-        status['context']['data'] = status['context']['data'].decode('utf-8')
+    utils.normalize_write_ctx(status)
+
     return status
 
 

--- a/synse_server/utils.py
+++ b/synse_server/utils.py
@@ -9,6 +9,30 @@ import ujson
 from synse_server import config
 
 
+def normalize_write_ctx(data: Dict) -> None:
+    """Normalize the given write context for consistent response formatting.
+
+    The write context is the dictionary under the 'context' key which contains
+    the reflected write data (action, data, transaction) which is included as
+    part of the API write and transaction responses.
+
+    The normalization process includes:
+      * Ensuring the "data" field is encoded as utf-8
+      * Ensuring that an empty "transaction" field is omitted from the response.
+    """
+    if 'context' not in data:
+        return
+
+    # Ensure the 'data' field is encoded as utf-8
+    if 'data' in data['context']:
+        if isinstance(data['context']['data'], bytes):
+            data['context']['data'] = data['context']['data'].decode('utf-8')
+
+    # Ensure an empty 'transaction' field is omitted
+    if 'transaction' in data['context'] and not data['context']['transaction']:
+        del data['context']['transaction']
+
+
 def rfc3339now() -> str:
     """Create an RFC3339 formatted timestamp for the current UTC time.
 

--- a/tests/unit/cmd/test_transaction.py
+++ b/tests/unit/cmd/test_transaction.py
@@ -157,8 +157,7 @@ async def test_transaction_client_ok(mocker, simple_plugin):
                 'timeout': '',
                 'context': {
                     'action': 'test',
-                    'data': b'',
-                    'transaction': '',
+                    'data': '',
                 },
             }
 

--- a/tests/unit/cmd/test_write.py
+++ b/tests/unit/cmd/test_write.py
@@ -154,8 +154,7 @@ async def test_write_async_ok(mocker, simple_plugin):
                     'timeout': '5s',
                     'context': {
                         'action': 'foo',
-                        'data': b'',
-                        'transaction': '',
+                        'data': '',
                     },
                 },
                 {
@@ -164,8 +163,7 @@ async def test_write_async_ok(mocker, simple_plugin):
                     'timeout': '5s',
                     'context': {
                         'action': 'bar',
-                        'data': b'',
-                        'transaction': '',
+                        'data': '',
                     },
                 },
                 {
@@ -174,8 +172,7 @@ async def test_write_async_ok(mocker, simple_plugin):
                     'timeout': '5s',
                     'context': {
                         'action': 'baz',
-                        'data': b'',
-                        'transaction': '',
+                        'data': '',
                     },
                 },
             ]
@@ -354,8 +351,7 @@ async def test_write_sync_ok(mocker, simple_plugin):
                     'status': 'DONE',
                     'context': {
                         'action': 'foo',
-                        'data': b'',
-                        'transaction': '',
+                        'data': '',
                     },
                 },
                 {
@@ -368,8 +364,7 @@ async def test_write_sync_ok(mocker, simple_plugin):
                     'status': 'DONE',
                     'context': {
                         'action': 'bar',
-                        'data': b'',
-                        'transaction': '',
+                        'data': '',
                     },
                 },
                 {
@@ -382,8 +377,7 @@ async def test_write_sync_ok(mocker, simple_plugin):
                     'status': 'DONE',
                     'context': {
                         'action': 'baz',
-                        'data': b'',
-                        'transaction': '',
+                        'data': '',
                     },
                 },
             ]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,6 +5,26 @@ from sanic.response import HTTPResponse
 from synse_server import utils
 
 
+@pytest.mark.parametrize(
+    'data,expected', [
+        ({}, {}),
+        ({'foo': 'bar'}, {'foo': 'bar'}),
+        ({'context': {'data': 'abc'}}, {'context': {'data': 'abc'}}),
+        ({'context': {'data': b'abc'}}, {'context': {'data': 'abc'}}),
+        ({'context': {'transaction': None}}, {'context': {}}),
+        ({'context': {'transaction': ''}}, {'context': {}}),
+        ({'context': {'transaction': '123'}}, {'context': {'transaction': '123'}}),
+        (
+            {'context': {'data': b'10', 'transaction': '', 'action': 'a'}},
+            {'context': {'data': '10', 'action': 'a'}},
+        ),
+    ],
+)
+def test_normalize_write_ctx(data, expected):
+    utils.normalize_write_ctx(data)
+    assert data == expected
+
+
 @pytest.mark.usefixtures('patch_datetime_utcnow')
 def test_rfc3339now():
     actual = utils.rfc3339now()


### PR DESCRIPTION
This PR:
- creates a utility function to normalize the reflected write context for writes/transactions, adding a step to omit the 'transaction' field if a user-defined transaction was not specified.
- adds and updates unit tests.

fixes #359 