### PR TITLE
test: cleaning up + normalizing test definitions

### DIFF
--- a/tests/unit/api/test_http.py
+++ b/tests/unit/api/test_http.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.api.http`` module."""
 
 import asynctest
 import pytest

--- a/tests/unit/api/test_websocket.py
+++ b/tests/unit/api/test_websocket.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.api.websocket`` module."""
 
 import json
 

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.cmd.config`` module."""
 
 import pytest
 

--- a/tests/unit/cmd/test_info.py
+++ b/tests/unit/cmd/test_info.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.cmd.info`` module."""
 
 import asynctest
 import pytest

--- a/tests/unit/cmd/test_plugin.py
+++ b/tests/unit/cmd/test_plugin.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.cmd.plugin`` module."""
 
 import pytest
 from synse_grpc import api, client

--- a/tests/unit/cmd/test_read.py
+++ b/tests/unit/cmd/test_read.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.cmd.read`` module."""
 
 import asynctest
 import pytest

--- a/tests/unit/cmd/test_scan.py
+++ b/tests/unit/cmd/test_scan.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.cmd.scan`` module."""
 
 import asynctest
 import pytest

--- a/tests/unit/cmd/test_tags.py
+++ b/tests/unit/cmd/test_tags.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.cmd.tags`` module."""
 
 import pytest
 

--- a/tests/unit/cmd/test_test.py
+++ b/tests/unit/cmd/test_test.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.cmd.test`` module."""
 
 import pytest
 

--- a/tests/unit/cmd/test_transaction.py
+++ b/tests/unit/cmd/test_transaction.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.cmd.transaction`` module."""
 
 import asynctest
 import pytest

--- a/tests/unit/cmd/test_version.py
+++ b/tests/unit/cmd/test_version.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.cmd.version`` module."""
 
 import pytest
 

--- a/tests/unit/cmd/test_write.py
+++ b/tests/unit/cmd/test_write.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.cmd.write`` module."""
 
 import asynctest
 import pytest

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+"""Fixture definitions for Synse Server unit tests."""
 
 import datetime
 import logging

--- a/tests/unit/discovery/test_kubernetes.py
+++ b/tests/unit/discovery/test_kubernetes.py
@@ -1,4 +1,4 @@
-"""Test the 'synse_server.discovery.kubernetes' Synse Server module."""
+"""Unit tests for the ``synse_server.discovery.kubernetes`` module."""
 
 import kubernetes as k8s
 import pytest

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.app`` module."""
 
 from synse_server import app, errors
 

--- a/tests/unit/test_backoff.py
+++ b/tests/unit/test_backoff.py
@@ -1,4 +1,4 @@
-"""Unit tests for the synse_server.backoff package."""
+"""Unit tests for the ``synse_server.backoff`` module."""
 
 from synse_server import backoff
 

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.errors`` module."""
 
 import json
 
@@ -12,7 +13,8 @@ class TestSynseErrorHandler:
     """Test cases for the ``synse_server.errors.SynseErrorHandler`` class."""
 
     @pytest.mark.parametrize(
-        'exception,code', [
+        'exception,code',
+        [
             (errors.SynseError, 500),
             (errors.InvalidUsage, 400),
             (errors.NotFound, 404),

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -1,6 +1,8 @@
+"""Unit tests for the ``synse_server.log`` module."""
 
 import logging
 
+import mock
 import structlog
 
 from synse_server import log
@@ -14,13 +16,8 @@ def test_setup_logger_defaults():
     assert logger.getEffectiveLevel() == logging.INFO
 
 
-def test_setup_logger_configured(mocker):
-    # Mock test data
-    mock_get = mocker.patch('synse_server.log.config.options.get', return_value='error')
-
-    # --- Test case -----------------------------
+@mock.patch('synse_server.log.config.options.get', return_value='error')
+def test_setup_logger_configured(mock_get):
     log.setup_logger()
     assert structlog.get_logger('synse_server').getEffectiveLevel() == logging.ERROR
-
-    mock_get.assert_called_once()
-    mock_get.assert_called_with('logging', 'info')
+    mock_get.assert_called_once_with('logging', 'info')

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,4 +1,6 @@
+"""Unit tests for the ``synse_server.server`` module."""
 
+import mock
 import pytest
 
 from synse_server import server
@@ -9,60 +11,34 @@ class TestSynse:
     Sanic server and performs setup for the Synse Server application.
     """
 
-    def test_init_ok(self, mocker):
-        # Mock test data
-        mock_initialize = mocker.patch(
-            'synse_server.server.Synse._initialize',
-        )
-
-        # --- Test case -----------------------------
+    @mock.patch('synse_server.server.Synse._initialize')
+    def test_init_ok(self, mock_init):
         synse = server.Synse()
         assert synse.host == '0.0.0.0'
         assert synse.port == 5000
         assert synse.log_header is True
         assert synse.app is not None
 
-        mock_initialize.assert_called_once()
+        mock_init.assert_called_once()
 
-    def test_initialize(self, mocker):
-        # Mock test data
-        mock_mkdirs = mocker.patch(
-            'os.makedirs',
-        )
-        mock_logger = mocker.patch(
-            'synse_server.server.setup_logger'
-        )
-        mock_reload_config = mocker.patch(
-            'synse_server.server.Synse.reload_config',
-        )
-
-        # --- Test case -----------------------------
+    @mock.patch('os.makedirs')
+    @mock.patch('synse_server.server.setup_logger')
+    @mock.patch('synse_server.server.Synse.reload_config')
+    def test_initialize(self, mock_reload, mock_logger, mock_mkdirs):
         synse = server.Synse()
 
         mock_logger.assert_called_once()
-        mock_reload_config.assert_called_once()
-        mock_mkdirs.assert_called()
+        mock_reload.assert_called_once()
         mock_mkdirs.assert_has_calls([
-            mocker.call(synse._server_config_dir, exist_ok=True),
-            mocker.call(synse._socket_dir, exist_ok=True),
+            mock.call(synse._server_config_dir, exist_ok=True),
+            mock.call(synse._socket_dir, exist_ok=True),
         ])
 
-    def test_run_ok_with_metrics(self, mocker):
-        # Mock test data
-        mocker.patch.dict('synse_server.config.options._full_config', {
-            'metrics': {
-                'enabled': True,
-            },
-        })
-        mock_initialize = mocker.patch(
-            'synse_server.server.Synse._initialize',
-        )
-        mock_run = mocker.patch(
-            'synse_server.loop.synse_loop.run_forever'
-        )
-        mock_write = mocker.patch('sys.stdout.write')
-
-        # --- Test case -----------------------------
+    @mock.patch.dict('synse_server.config.options._full_config', {'metrics': {'enabled': True}})
+    @mock.patch('synse_server.server.Synse._initialize')
+    @mock.patch('synse_server.loop.synse_loop.run_forever')
+    @mock.patch('sys.stdout.write')
+    def test_run_ok_with_metrics(self, mock_write, mock_run, mock_init):
         synse = server.Synse()
         assert 'metrics' not in synse.app.router.routes_names.keys()
 
@@ -70,75 +46,42 @@ class TestSynse:
         assert 'metrics' in synse.app.router.routes_names.keys()
 
         mock_write.assert_called_once()
-        mock_initialize.assert_called_once()
+        mock_init.assert_called_once()
         mock_run.assert_called_once()
 
-    def test_run_ok_with_ssl(self, mocker):
-        # Mock test data
-        mocker.patch.dict('synse_server.config.options._full_config', {
-            'ssl': {
-                'cert': 'test-cert',
-                'key': 'test-key',
-            },
-        })
-        mock_initialize = mocker.patch(
-            'synse_server.server.Synse._initialize',
-        )
-        mock_run = mocker.patch(
-            'synse_server.loop.synse_loop.run_forever'
-        )
-        mock_write = mocker.patch('sys.stdout.write')
-
-        # --- Test case -----------------------------
+    @mock.patch.dict(
+        'synse_server.config.options._full_config',
+        {'ssl': {'cert': 'test-cert', 'key': 'test-key'}},
+    )
+    @mock.patch('synse_server.server.Synse._initialize')
+    @mock.patch('synse_server.loop.synse_loop.run_forever')
+    @mock.patch('sys.stdout.write')
+    def test_run_ok_with_ssl(self, mock_write, mock_run, mock_init):
         synse = server.Synse(log_header=False)
         synse.run()
 
         mock_write.assert_not_called()
-        mock_initialize.assert_called_once()
+        mock_init.assert_called_once()
         mock_run.assert_called_once()
 
-    def test_run_error(self, mocker):
-        # Mock test data
-        mocker.patch.dict('synse_server.config.options._full_config', {
-            'ssl': {
-                'cert': 'test-cert',
-                'key': 'test-key',
-            },
-        })
-        mock_initialize = mocker.patch(
-            'synse_server.server.Synse._initialize',
-        )
-        mock_run = mocker.patch(
-            'synse_server.loop.synse_loop.run_forever',
-            side_effect=ValueError(),
-        )
-
-        # --- Test case -----------------------------
+    @mock.patch('synse_server.server.Synse._initialize')
+    @mock.patch('synse_server.loop.synse_loop.run_forever', side_effect=ValueError)
+    def test_run_error(self, mock_run, mock_init):
         synse = server.Synse(log_header=False)
 
         with pytest.raises(ValueError):
             synse.run()
 
-        mock_initialize.assert_called_once()
+        mock_init.assert_called_once()
         mock_run.assert_called_once()
 
-    def test_reload_config(self, mocker):
-        # Mock test data
-        mock_parse = mocker.patch(
-            'bison.Bison.parse',
-        )
-        mock_validate = mocker.patch(
-            'bison.Bison.validate'
-        )
-        mock_initialize = mocker.patch(
-            'synse_server.server.Synse._initialize',
-        )
-
-        # --- Test case -----------------------------
+    @mock.patch('bison.Bison.parse')
+    @mock.patch('bison.Bison.validate')
+    @mock.patch('synse_server.server.Synse._initialize')
+    def test_reload_config(self, mock_init, mock_validate, mock_parse):
         synse = server.Synse(log_header=False)
         synse.reload_config()
 
         mock_validate.assert_called_once()
-        mock_parse.assert_called_once()
-        mock_parse.assert_called_with(requires_cfg=False)
-        mock_initialize.assert_called_once()
+        mock_parse.assert_called_once_with(requires_cfg=False)
+        mock_init.assert_called_once()

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -1,3 +1,4 @@
+"""Unit tests for the ``synse_server.tasks`` module."""
 
 from unittest import mock
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,4 +1,6 @@
+"""Unit tests for the ``synse_server.utils`` module."""
 
+import mock
 import pytest
 from sanic.response import HTTPResponse
 
@@ -6,14 +8,15 @@ from synse_server import utils
 
 
 @pytest.mark.parametrize(
-    'data,expected', [
-        ({}, {}),
-        ({'foo': 'bar'}, {'foo': 'bar'}),
-        ({'context': {'data': 'abc'}}, {'context': {'data': 'abc'}}),
-        ({'context': {'data': b'abc'}}, {'context': {'data': 'abc'}}),
-        ({'context': {'transaction': None}}, {'context': {}}),
-        ({'context': {'transaction': ''}}, {'context': {}}),
-        ({'context': {'transaction': '123'}}, {'context': {'transaction': '123'}}),
+    'data,expected',
+    [
+        ({}, {},),
+        ({'foo': 'bar'}, {'foo': 'bar'},),
+        ({'context': {'data': 'abc'}}, {'context': {'data': 'abc'}},),
+        ({'context': {'data': b'abc'}}, {'context': {'data': 'abc'}},),
+        ({'context': {'transaction': None}}, {'context': {}},),
+        ({'context': {'transaction': ''}}, {'context': {}},),
+        ({'context': {'transaction': '123'}}, {'context': {'transaction': '123'}},),
         (
             {'context': {'data': b'10', 'transaction': '', 'action': 'a'}},
             {'context': {'data': '10', 'action': 'a'}},
@@ -32,7 +35,8 @@ def test_rfc3339now():
 
 
 @pytest.mark.parametrize(
-    'data,expected', [
+    'data,expected',
+    [
         ({'foo': 'bar'}, '{"foo":"bar"}\n'),
         ({'one': 1}, '{"one":1}\n'),
         ({'foo': 'bar', 'one': 1}, '{"foo":"bar","one":1}\n'),
@@ -41,7 +45,7 @@ def test_rfc3339now():
         ([1, 2, 3], '[1,2,3]\n'),
         ([1, 2, [2, 3, 4]], '[1,2,[2,3,4]]\n'),
         ([{'one': 1}, {'two': 2}], '[{"one":1},{"two":2}]\n'),
-    ]
+    ],
 )
 def test_dumps(data, expected):
     actual = utils._dumps(data)
@@ -66,11 +70,8 @@ def test_http_json_response_from_list():
     assert actual.content_type == 'application/json'
 
 
-def test_http_json_response_from_dict_pretty(mocker):
-    # Mock test data
-    mock_get = mocker.patch('synse_server.config.options.get', return_value=True)
-
-    # --- Test case -----------------------------
+@mock.patch('synse_server.config.options.get', return_value=True)
+def test_http_json_response_from_dict_pretty(mock_get):
     actual = utils.http_json_response({'status': 'ok'})
 
     assert isinstance(actual, HTTPResponse)
@@ -81,11 +82,8 @@ def test_http_json_response_from_dict_pretty(mocker):
     mock_get.assert_called_with('pretty_json')
 
 
-def test_http_json_response_from_list_pretty(mocker):
-    # Mock test data
-    mock_get = mocker.patch('synse_server.config.options.get', return_value=True)
-
-    # --- Test case -----------------------------
+@mock.patch('synse_server.config.options.get', return_value=True)
+def test_http_json_response_from_list_pretty(mock_get):
     actual = utils.http_json_response(['a', 'b', 'c'])
 
     assert isinstance(actual, HTTPResponse)


### PR DESCRIPTION
This PR:
- adds/updates docstrings for unit test files
- updates some of the usages of `mock` to be easier to maintain / more consistent. the test cases themselves don't change, just how mocking is defined.