### PR TITLE
fix bug where plugin active state was not being set on timeout error for reads

### DIFF
--- a/synse_server/cmd/read.py
+++ b/synse_server/cmd/read.py
@@ -91,13 +91,13 @@ async def read(
 
             try:
                 with p as client:
-                    data = client.read()
+                    for reading in client.read():
+                        readings.append(reading_to_dict(reading))
             except Exception as e:
                 raise errors.ServerError(
                     'error while issuing gRPC request: read'
                 ) from e
-            for reading in data:
-                readings.append(reading_to_dict(reading))
+
         logger.debug('got readings', count=len(readings), command='READ')
         return readings
 
@@ -135,14 +135,12 @@ async def read(
 
             try:
                 with p as client:
-                    data = client.read(tags=group)
+                    for r in client.read(tags=group):
+                        results[f'{r.id}{r.type}{r.timestamp}'] = reading_to_dict(r)
             except Exception as e:
                 raise errors.ServerError(
                     'error while issuing gRPC request: read'
                 ) from e
-
-            for r in data:
-                results[f'{r.id}{r.type}{r.timestamp}'] = reading_to_dict(r)
 
     readings = list(results.values())
     logger.debug('got readings', count=len(readings), command='READ')
@@ -169,14 +167,13 @@ async def read_device(device_id: str) -> List[Dict[str, Any]]:
     readings = []
     try:
         with p as client:
-            data = client.read(device_id=device_id)
+            for reading in client.read(device_id=device_id):
+                readings.append(reading_to_dict(reading))
+
     except Exception as e:
         raise errors.ServerError(
             'error while issuing gRPC request: read device',
         ) from e
-
-    for reading in data:
-        readings.append(reading_to_dict(reading))
 
     logger.debug('got readings', count=len(readings), command='READ DEVICE')
     return readings

--- a/synse_server/plugin.py
+++ b/synse_server/plugin.py
@@ -365,6 +365,9 @@ class Plugin:
     def __str__(self) -> str:
         return f'<Plugin ({self.tag}): {self.id}>'
 
+    def __repr__(self) -> str:
+        return str(self)
+
     def __del__(self) -> None:
         self.cancel_tasks()
 


### PR DESCRIPTION
This PR:
- fixes a bug where plugin state was not being set to inactive if a read failed (timeout error). this was because the value returned by the client is a generator, but generator iteration happened outside the scope of the client context, which is where the plugin activity state gets set when the context is exited with an error.
- adds a `__repr__` definition to the `Plugin` class so logged collections of plugins are human readable
- adds regression test for the bugfix

fixes #379 