### PR TITLE
bugfix: enable env binds for ssl.cert and ssl.key options

### DIFF
--- a/synse_server/config.py
+++ b/synse_server/config.py
@@ -36,8 +36,8 @@ scheme = Scheme(
         ))
     )),
     DictOption('ssl', required=False, scheme=Scheme(
-        Option('cert', field_type=str),
-        Option('key', field_type=str),
+        Option('cert', bind_env=True, field_type=str),
+        Option('key', bind_env=True, field_type=str),
     )),
     DictOption('metrics', scheme=Scheme(
         Option('enabled', default=False, bind_env=True, field_type=bool),


### PR DESCRIPTION
This PR:
-  adds env binds for ssl.cert and ssl.key so they can be configured via ENV

fixes #387 