### PR TITLE
bugfix: terminate server if invalid grpc cert is specified

### DIFF
--- a/synse_server/errors.py
+++ b/synse_server/errors.py
@@ -115,3 +115,13 @@ class ServerError(SynseError):
 
     http_code = 500
     description = 'error processing the request'
+
+
+class ClientCreateError(ServerError):
+    """Synse Server was unable to create a client (e.g. gRPC).
+
+    This error does not indicate errors with communicating with a connected
+    client. It should only be used in cases where client creation itself fails
+    for any reason, whether it is invalid TLS options, or other invalid
+    configuration.
+    """

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -64,6 +64,23 @@ class TestSynse:
         mock_init.assert_called_once()
         mock_run.assert_called_once()
 
+    @mock.patch.dict(
+        'synse_server.config.options._full_config',
+        {'grpc': {'tls': {'cert': 'test-cert'}}},
+    )
+    @mock.patch('synse_server.server.Synse._initialize')
+    @mock.patch('synse_server.loop.synse_loop.run_forever')
+    @mock.patch('sys.stdout.write')
+    def test_run_grpc_cert_error(self, mock_write, mock_run, mock_init):
+        synse = server.Synse(log_header=False)
+
+        with pytest.raises(FileNotFoundError):
+            synse.run()
+
+        mock_write.assert_not_called()
+        mock_init.assert_called_once()
+        mock_run.assert_not_called()
+
     @mock.patch('synse_server.server.Synse._initialize')
     @mock.patch('synse_server.loop.synse_loop.run_forever', side_effect=ValueError)
     def test_run_error(self, mock_run, mock_init):


### PR DESCRIPTION
This PR:
- adds a check to verify  that the grpc cert exists, and fails if not
- adds exception handling around grpc client creation, and propagates the exception up if client creation fails
- adds regression tests

fixes #388