### PR TITLE
bugfix: catch any exceptions raised during server creation

### DIFF
--- a/synse_server/server.py
+++ b/synse_server/server.py
@@ -170,7 +170,13 @@ class Synse:
             return_asyncio_server=True,
             access_log=False,
         )
-        asyncio.ensure_future(self.server, loop=loop.synse_loop)
+        t = asyncio.ensure_future(self.server, loop=loop.synse_loop)
+
+        # Wait until the server has been created and run. If there was an error
+        # creating the server, this will raise an exception.
+        loop.synse_loop.run_until_complete(t)
+
+        # The server is now running on the loop, so run the loop forever.
         loop.synse_loop.run_forever()
 
     def reload_config(self) -> None:


### PR DESCRIPTION
This PR:
- Fixes a bug where an exception raised during sanic server creation wasn't being retrieved from the task that the server creation was being performed in.


fixes #389