### PR TITLE
feat: add --profile flag to enable simpler debug profiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,15 @@ RUN groupadd -g 51453 synse \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tini curl \
  && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /synse \
  && mkdir -p /etc/synse \
+ && chown -R synse:synse /synse \
  && chown -R synse:synse /etc/synse
 
 COPY --from=builder /build /usr/local
 COPY ./assets/favicon.ico /etc/synse/static/favicon.ico
 
 USER synse
+WORKDIR synse
+
 ENTRYPOINT ["/usr/bin/tini", "--", "synse_server"]


### PR DESCRIPTION
This PR:
- adds a `--profile` flag to run synse with profiling enabled
- updates Dockerfile so the workdir is well known (makes it easier to extract profiling data)
- sets up signal listeners so synse server can be terminated gracefully

fixes #386