### PR TITLE
bugfix: fix middleware logger to not get body length for streamed responses

### DIFF
--- a/synse_server/app.py
+++ b/synse_server/app.py
@@ -70,11 +70,18 @@ def on_request(request: Request) -> None:
 def on_response(request: Request, response: HTTPResponse) -> None:
     """Middleware function that runs prior to returning a response via Sanic."""
 
+    # Default bytes. If this is a StreamingHTTPResponse, this value is
+    # used, since there is no response.body for those responses.
+    # (https://github.com/vapor-ware/synse-server/issues/396)
+    byte_count = -1
+    if hasattr(response, 'body') and response.body is not None:
+        byte_count = len(response.body)
+
     logger.debug(
         'returning HTTP response',
         request=f'{request.method} {request.url}',
         status=response.status,
-        bytes=len(response.body),
+        bytes=byte_count,
     )
 
     # Unbind the request ID from the logger.

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,5 +1,8 @@
 """Unit tests for the ``synse_server.app`` module."""
 
+from sanic.response import HTTPResponse, StreamingHTTPResponse
+from structlog import contextvars
+
 from synse_server import app, errors
 
 
@@ -14,3 +17,43 @@ def test_new_app():
     assert 'core-http' in synse_app.blueprints
     assert 'v3-http' in synse_app.blueprints
     assert 'v3-websocket' in synse_app.blueprints
+
+
+def test_on_response_normal_http_response():
+    class MockRequest:
+        method = 'GET'
+        url = 'http://localhost'
+
+    req = MockRequest()
+    resp = HTTPResponse()
+
+    contextvars.bind_contextvars(
+        request_id='test-request',
+    )
+    ctx = contextvars._get_context()
+    assert 'test-request' == ctx.get('request_id')
+
+    app.on_response(req, resp)
+
+    ctx = contextvars._get_context()
+    assert ctx.get('request_id') is None
+
+
+def test_on_response_streaming_http_response():
+    class MockRequest:
+        method = 'GET'
+        url = 'http://localhost'
+
+    req = MockRequest()
+    resp = StreamingHTTPResponse(None)
+
+    contextvars.bind_contextvars(
+        request_id='test-request',
+    )
+    ctx = contextvars._get_context()
+    assert 'test-request' == ctx.get('request_id')
+
+    app.on_response(req, resp)
+
+    ctx = contextvars._get_context()
+    assert ctx.get('request_id') is None


### PR DESCRIPTION
This PR:
- fixes a bug where log context was referencing an attribute which did not  exist  for streamed http responses
- adds regression  tests

fixes #396