### PR TITLE
Setup basic GitHub actions workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,21 @@
+name: lint
+on:
+  push: {}
+  pull_request: {}
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Python 3.8 Lint
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip setuptools wheel
+        python -m pip install -U tox tox-gh-actions
+    - name: Lint
+      run: tox -e lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py-version: ['3.6', '3.7', '3.8']
+        py-version: ['3.7', '3.8']
     name: Python ${{ matrix.py-version }} Test
     steps:
     - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,25 @@
+name: test
+on:
+  push: {}
+  pull_request: {}
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        py-version: ['3.6', '3.7', '3.8']
+    name: Python ${{ matrix.py-version }} Test
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.py-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip setuptools wheel
+        python -m pip install -U tox tox-gh-actions
+    - name: Run tests
+      run: tox tests/unit

--- a/.jenkins
+++ b/.jenkins
@@ -14,8 +14,13 @@ pipeline {
     }
 
     stage('Lint') {
+      agent {
+        label 'python-3.8'
+      }
       steps {
-        sh 'tox -e lint'
+        container('python') {
+          sh 'tox -e lint'
+        }
       }
     }
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     license=pkg['__license__'],
     packages=find_packages(exclude=['tests.*', 'tests']),
     include_package_data=True,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     package_data={
         '': ['LICENSE'],
     },
@@ -57,6 +57,7 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,16 @@
 [tox]
-envlist = py{36,37,38}
+envlist = py{37,38}
 skip_missing_interpreters = True
 
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38,lint
 
 
 [testenv]
 basepython =
-    py36: python3.6
     py37: python3.7
     py38: python3.8
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,20 @@
 [tox]
-envlist = py3
+envlist = py{36,37,38}
+skip_missing_interpreters = True
+
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38,lint
 
 
 [testenv]
+basepython =
+    py36: python3.6
+    py37: python3.7
+    py38: python3.8
 deps =
     pip-tools
 commands =
@@ -33,6 +45,7 @@ commands =
 
 
 [testenv:lint]
+basepython=python3
 deps =
     isort>=5.0.0
     flake8


### PR DESCRIPTION
This PR:
- sets up basic github actions workflows to give public visibility/access to CI
- removes support for py36 (synse-server uses asyncio API methods introduced in 3.7)
- updates jenkins CI pipeline to run linting in py38 container since 3.6 is no longer supported. An upcoming PR will update the entire jenkins config to use the new style, so this is just an interim fix to get the PR checks passing.