### PR TITLE
Sanic update

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,21 +7,22 @@
 aiohttp==3.6.2            # via -r test-requirements.in
 async-timeout==3.0.1      # via aiohttp
 asynctest==0.13.0         # via -r test-requirements.in
-attrs==19.3.0             # via aiohttp, pytest
+attrs==20.1.0             # via aiohttp, pytest
 chardet==3.0.4            # via aiohttp
-coverage==5.0.4           # via pytest-cov
-idna==2.9                 # via yarl
+coverage==5.2.1           # via pytest-cov
+idna==2.10                # via yarl
+iniconfig==1.0.1          # via pytest
 mock==4.0.2               # via -r test-requirements.in
-more-itertools==8.2.0     # via pytest
-multidict==4.7.5          # via aiohttp, yarl
-packaging==20.3           # via pytest
+more-itertools==8.4.0     # via pytest
+multidict==4.7.6          # via aiohttp, yarl
+packaging==20.4           # via pytest
 pluggy==0.13.1            # via pytest
-py==1.8.1                 # via pytest
-pyparsing==2.4.6          # via packaging
-pytest-asyncio==0.10.0    # via -r test-requirements.in
-pytest-cov==2.8.1         # via -r test-requirements.in
-pytest-mock==2.0.0        # via -r test-requirements.in
-pytest==5.4.1             # via -r test-requirements.in, pytest-asyncio, pytest-cov, pytest-mock
-six==1.14.0               # via packaging
-wcwidth==0.1.9            # via pytest
-yarl==1.4.2               # via aiohttp
+py==1.9.0                 # via pytest
+pyparsing==2.4.7          # via packaging
+pytest-asyncio==0.14.0    # via -r test-requirements.in
+pytest-cov==2.10.1        # via -r test-requirements.in
+pytest-mock==3.3.1        # via -r test-requirements.in
+pytest==6.0.1             # via -r test-requirements.in, pytest-asyncio, pytest-cov, pytest-mock
+six==1.15.0               # via packaging
+toml==0.10.1              # via pytest
+yarl==1.5.1               # via aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,42 +5,42 @@
 #    pip-compile --output-file=requirements.txt setup.py
 #
 aiocache==0.11.1          # via synse_server (setup.py)
-aiofiles==0.4.0           # via sanic
+aiofiles==0.5.0           # via sanic
 bison==0.1.2              # via synse_server (setup.py)
-cachetools==4.0.0         # via google-auth
-certifi==2019.11.28       # via httpx, kubernetes, requests
+cachetools==4.1.1         # via google-auth
+certifi==2020.6.20        # via httpx, kubernetes, requests
 chardet==3.0.4            # via httpx, requests
-google-auth==1.12.0       # via kubernetes
-grpcio==1.27.2            # via synse-grpc, synse_server (setup.py)
-h11==0.8.1                # via httpx
+google-auth==1.20.1       # via kubernetes
+grpcio==1.31.0            # via synse-grpc, synse_server (setup.py)
+h11==0.9.0                # via httpx
 h2==3.2.0                 # via httpx
 hpack==3.0.0              # via h2
-hstspreload==2020.3.25    # via httpx
+hstspreload==2020.8.25    # via httpx
 httptools==0.1.1          # via sanic
-httpx==0.9.3              # via sanic
+httpx==0.11.1             # via sanic
 hyperframe==5.2.0         # via h2
-idna==2.9                 # via httpx, requests
+idna==2.10                # via httpx, requests
 kubernetes==11.0.0        # via synse_server (setup.py)
-multidict==4.7.5          # via sanic
+multidict==4.7.6          # via sanic
 oauthlib==3.1.0           # via requests-oauthlib
-prometheus-client==0.7.1  # via synse_server (setup.py)
-protobuf==3.11.3          # via synse-grpc
+prometheus-client==0.8.0  # via synse_server (setup.py)
+protobuf==3.13.0          # via synse-grpc
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 python-dateutil==2.8.1    # via kubernetes
 pyyaml==5.3.1             # via bison, kubernetes, synse_server (setup.py)
 requests-oauthlib==1.3.0  # via kubernetes
-requests==2.23.0          # via kubernetes, requests-oauthlib
-rfc3986==1.3.2            # via httpx
-rsa==4.0                  # via google-auth
-sanic==19.12.2            # via synse_server (setup.py)
+requests==2.24.0          # via kubernetes, requests-oauthlib
+rfc3986==1.4.0            # via httpx
+rsa==4.6                  # via google-auth
+sanic==20.6.3             # via synse_server (setup.py)
 shortuuid==1.0.1          # via synse_server (setup.py)
-six==1.14.0               # via google-auth, grpcio, kubernetes, protobuf, python-dateutil, structlog, websocket-client
+six==1.15.0               # via google-auth, grpcio, kubernetes, protobuf, python-dateutil, structlog, websocket-client
 sniffio==1.1.0            # via httpx
 structlog==20.1.0         # via synse_server (setup.py)
 synse-grpc==3.0.0         # via synse_server (setup.py)
 ujson==2.0.3              # via sanic
-urllib3==1.25.8           # via kubernetes, requests
+urllib3==1.25.10          # via httpx, kubernetes, requests
 uvloop==0.14.0            # via sanic
 websocket-client==0.57.0  # via kubernetes
 websockets==8.1           # via sanic, synse_server (setup.py)

--- a/synse_server/metrics.py
+++ b/synse_server/metrics.py
@@ -12,8 +12,6 @@ from sanic.response import HTTPResponse, raw
 
 class Monitor:
 
-    _req_start_time = '__req_start_time'
-
     #
     # Metrics for Synse Server's HTTP API
     #
@@ -134,11 +132,11 @@ class Monitor:
 
         @self.app.middleware('request')
         async def before_request(request: Request) -> None:
-            request[self._req_start_time] = time.time()
+            request.ctx.req_start_time = time.time()
 
         @self.app.middleware('response')
         async def before_response(request: Request, response: HTTPResponse) -> None:
-            latency = time.time() - request[self._req_start_time]
+            latency = time.time() - request.ctx.req_start_time
 
             # WebSocket handler ignores response logic, so default
             # to a 200 response in such case.

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     pip-tools
 commands =
     pip-sync {toxinidir}/requirements.txt {toxinidir}/requirements-test.txt
-    pytest -s \
+    pytest -s -vv \
         --disable-warnings \
         --cov-report html \
         --cov-report term \
@@ -26,6 +26,7 @@ commands =
 
 
 [testenv:deps]
+basepython=python3
 deps =
     pip-tools
 commands =
@@ -34,6 +35,7 @@ commands =
 
 
 [testenv:fmt]
+basepython=python3
 deps =
     isort>=5.0.0
     autopep8


### PR DESCRIPTION
This PR:
- updates project dependencies,  bringing Sanic up to 20.X, which includes breaking changes about how request context is accessed
- updates the prometheus metrics middleware for the new approach towards using request context
- runs tests more verbosely and updates tox to ensure the basepython is  specified

fixes #405