### PR TITLE
ci: update jenkins config

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 // Include this shared CI repository to load script helpers and libraries.
-library identifier: 'vapor@1.0.0-RC4', retriever: modernSCM([
+library identifier: 'vapor@develop', retriever: modernSCM([
   $class: 'GitSCMSource',
   remote: 'https://github.com/vapor-ware/ci-shared.git',
   credentialsId: 'vio-bot-gh',
@@ -14,4 +14,5 @@ pythonPipeline([
   'skipIntegrationTest': true,
   'releaseToPypi': false,
   'publishToGitHub': true,
+  'skipSetup': true,
 ])


### PR DESCRIPTION
This PR:
-  updates jenkins ci,  pointing the ci-shared ref to the develop branch namely for testing. this will  need to be updated to point to  a stable release in the future.