### PR TITLE
feat: update grpc dependency to allow device info in reading responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ shortuuid==1.0.1          # via synse_server (setup.py)
 six==1.15.0               # via google-auth, grpcio, kubernetes, protobuf, python-dateutil, structlog, websocket-client
 sniffio==1.1.0            # via httpx
 structlog==20.1.0         # via synse_server (setup.py)
-synse-grpc==3.0.0         # via synse_server (setup.py)
+synse-grpc==3.1.0         # via synse_server (setup.py)
 ujson==2.0.3              # via sanic
 urllib3==1.25.10          # via httpx, kubernetes, requests
 uvloop==0.14.0            # via sanic

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'shortuuid',
         'structlog>=20.1.0',
         'websockets',
-        'synse-grpc==3.0.0',
+        'synse-grpc==3.1.0',
     ],
     zip_safe=False,
     classifiers=[

--- a/synse_server/cmd/read.py
+++ b/synse_server/cmd/read.py
@@ -42,6 +42,7 @@ def reading_to_dict(reading: api.V3Reading) -> Dict[str, Any]:
         'timestamp': reading.timestamp,
         'type': reading.type,
         'device_type': reading.deviceType,
+        'device_info': reading.deviceInfo,
         'unit': unit,
         'value': value,
         'context': dict(reading.context),

--- a/tests/unit/cmd/test_read.py
+++ b/tests/unit/cmd/test_read.py
@@ -180,6 +180,7 @@ async def test_read_ok_no_tags(mocker, simple_plugin, temperature_reading, humid
             'timestamp': '2019-04-22T13:30:00Z',
             'type': 'temperature',
             'device_type': 'temperature',
+            'device_info': 'Example Temperature Device',
             'unit': {
                 'name': 'celsius',
                 'symbol': 'C',
@@ -194,6 +195,7 @@ async def test_read_ok_no_tags(mocker, simple_plugin, temperature_reading, humid
             'timestamp': '2019-04-22T13:30:00Z',
             'type': 'humidity',
             'device_type': 'humidity',
+            'device_info': 'Example Humidity Device',
             'unit': {
                 'name': 'percent',
                 'symbol': '%',
@@ -240,6 +242,7 @@ async def test_read_ok_tags_with_ns(mocker, simple_plugin, state_reading):
             'timestamp': '2019-04-22T13:30:00Z',
             'type': 'state',
             'device_type': 'led',
+            'device_info': 'Example LED Device',
             'value': 'on',
             'unit': None,
             'context': {},
@@ -286,6 +289,7 @@ async def test_read_ok_tags_without_ns(mocker, simple_plugin, state_reading):
             'timestamp': '2019-04-22T13:30:00Z',
             'type': 'state',
             'device_type': 'led',
+            'device_info': 'Example LED Device',
             'value': 'on',
             'unit': None,
             'context': {},
@@ -332,6 +336,7 @@ async def test_read_ok_single_tag_group_without_ns(mocker, simple_plugin, state_
             'timestamp': '2019-04-22T13:30:00Z',
             'type': 'state',
             'device_type': 'led',
+            'device_info': 'Example LED Device',
             'value': 'on',
             'unit': None,
             'context': {},
@@ -378,6 +383,7 @@ async def test_read_ok_single_tag_group_without_ns_with_plugin(
             'timestamp': '2019-04-22T13:30:00Z',
             'type': 'state',
             'device_type': 'led',
+            'device_info': 'Example LED Device',
             'value': 'on',
             'unit': None,
             'context': {},
@@ -489,6 +495,7 @@ async def test_read_device_ok(mocker, simple_plugin, temperature_reading):
                 'timestamp': '2019-04-22T13:30:00Z',
                 'type': 'temperature',
                 'device_type': 'temperature',
+                'device_info': 'Example Temperature Device',
                 'unit': {
                     'name': 'celsius',
                     'symbol': 'C',
@@ -578,6 +585,7 @@ async def test_read_cache_ok(mocker, simple_plugin, humidity_reading):
             'timestamp': '2019-04-22T13:30:00Z',
             'type': 'humidity',
             'device_type': 'humidity',
+            'device_info': 'Example Humidity Device',
             'unit': {
                 'name': 'percent',
                 'symbol': '%',
@@ -624,6 +632,7 @@ def test_reading_to_dict_1(temperature_reading):
         'timestamp': '2019-04-22T13:30:00Z',
         'type': 'temperature',
         'device_type': 'temperature',
+        'device_info': 'Example Temperature Device',
         'unit': {
             'name': 'celsius',
             'symbol': 'C',
@@ -643,6 +652,7 @@ def test_reading_to_dict_2(humidity_reading):
         'timestamp': '2019-04-22T13:30:00Z',
         'type': 'humidity',
         'device_type': 'humidity',
+        'device_info': 'Example Humidity Device',
         'unit': {
             'name': 'percent',
             'symbol': '%',
@@ -660,6 +670,7 @@ def test_reading_to_dict_3(state_reading):
         'timestamp': '2019-04-22T13:30:00Z',
         'type': 'state',
         'device_type': 'led',
+        'device_info': 'Example LED Device',
         'value': 'on',
         'unit': None,
         'context': {},

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -170,6 +170,7 @@ def temperature_reading():
         timestamp='2019-04-22T13:30:00Z',
         type='temperature',
         deviceType='temperature',
+        deviceInfo='Example Temperature Device',
         context={'zone': '1'},
         unit=api.V3OutputUnit(
             name='celsius',
@@ -188,6 +189,7 @@ def humidity_reading():
         timestamp='2019-04-22T13:30:00Z',
         type='humidity',
         deviceType='humidity',
+        deviceInfo='Example Humidity Device',
         unit=api.V3OutputUnit(
             name='percent',
             symbol='%',
@@ -205,6 +207,7 @@ def state_reading():
         timestamp='2019-04-22T13:30:00Z',
         type='state',
         deviceType='led',
+        deviceInfo='Example LED Device',
         string_value='on',
     )
 


### PR DESCRIPTION
After fighting with dependencies for a bit, I just did a manual edit of the requirements file. This has been tested and works, but the dependency management needs some updates because the test dependencies which get installed alongside prod dependencies have entered a state where the latest versions of various libraries force them out-of-sync, but thats an issue for a different PR.

This updates synse-server with the new grpc updates and updates tests. Verified working with a local build of synse server + plugin.

fixes #415 