### PR TITLE
update dependencies

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,57 +4,34 @@
 #
 #    pip-compile --output-file=requirements-test.txt test-requirements.in
 #
-aiohttp==3.7.4
-    # via -r test-requirements.in
-async-timeout==3.0.1
-    # via aiohttp
-asynctest==0.13.0
-    # via -r test-requirements.in
-attrs==20.1.0
-    # via
-    #   aiohttp
-    #   pytest
-chardet==3.0.4
-    # via aiohttp
-coverage==5.2.1
-    # via pytest-cov
-idna==2.10
-    # via yarl
-iniconfig==1.0.1
-    # via pytest
-mock==4.0.2
-    # via -r test-requirements.in
-more-itertools==8.4.0
-    # via pytest
-multidict==4.7.6
-    # via
-    #   aiohttp
-    #   yarl
-packaging==20.4
-    # via pytest
-pluggy==0.13.1
-    # via pytest
-py==1.9.0
-    # via pytest
-pyparsing==2.4.7
-    # via packaging
-pytest-asyncio==0.14.0
-    # via -r test-requirements.in
-pytest-cov==2.10.1
-    # via -r test-requirements.in
-pytest-mock==3.3.1
-    # via -r test-requirements.in
-pytest==6.0.1
-    # via
-    #   -r test-requirements.in
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-mock
-six==1.15.0
-    # via packaging
-toml==0.10.1
-    # via pytest
-typing-extensions==3.7.4.3
-    # via aiohttp
-yarl==1.5.1
-    # via aiohttp
+aiohttp==3.7.4.post0      # via -r test-requirements.in
+async-timeout==3.0.1      # via aiohttp
+asynctest==0.13.0         # via -r test-requirements.in
+attrs==20.3.0             # via aiohttp, pytest
+certifi==2020.12.5        # via httpx, requests
+chardet==4.0.0            # via aiohttp, requests
+coverage==5.5             # via pytest-cov
+h11==0.12.0               # via httpcore
+httpcore==0.12.3          # via httpx, sanic-testing
+httpx==0.16.1             # via sanic-testing
+idna==2.10                # via requests, yarl
+iniconfig==1.1.1          # via pytest
+mock==4.0.3               # via -r test-requirements.in
+multidict==5.1.0          # via aiohttp, yarl
+packaging==20.9           # via pytest
+pluggy==0.13.1            # via pytest
+py==1.10.0                # via pytest
+pyparsing==2.4.7          # via packaging
+pytest-asyncio==0.14.0    # via -r test-requirements.in
+pytest-cov==2.11.1        # via -r test-requirements.in
+pytest-mock==3.5.1        # via -r test-requirements.in
+pytest==6.2.2             # via -r test-requirements.in, pytest-asyncio, pytest-cov, pytest-mock
+requests==2.25.1          # via -r test-requirements.in
+rfc3986[idna2008]==1.4.0  # via httpx
+sanic-testing==0.3.0      # via -r test-requirements.in
+sniffio==1.2.0            # via httpcore, httpx
+toml==0.10.2              # via pytest
+typing-extensions==3.7.4.3  # via aiohttp
+urllib3==1.26.4           # via requests
+websockets==8.1           # via sanic-testing
+yarl==1.6.3               # via aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,44 +5,37 @@
 #    pip-compile --output-file=requirements.txt setup.py
 #
 aiocache==0.11.1          # via synse_server (setup.py)
-aiofiles==0.5.0           # via sanic
-bison==0.1.2              # via synse_server (setup.py)
-cachetools==4.1.1         # via google-auth
-certifi==2020.6.20        # via httpx, kubernetes, requests
-chardet==3.0.4            # via httpx, requests
-google-auth==1.20.1       # via kubernetes
-grpcio==1.31.0            # via synse-grpc, synse_server (setup.py)
-h11==0.9.0                # via httpx
-h2==3.2.0                 # via httpx
-hpack==3.0.0              # via h2
-hstspreload==2020.8.25    # via httpx
+aiofiles==0.6.0           # via sanic
+bison==0.1.3              # via synse_server (setup.py)
+cachetools==4.2.1         # via google-auth
+certifi==2020.12.5        # via kubernetes, requests
+chardet==4.0.0            # via requests
+google-auth==1.28.0       # via kubernetes
+grpcio==1.36.1            # via synse-grpc, synse_server (setup.py)
 httptools==0.1.1          # via sanic
-httpx==0.11.1             # via sanic
-hyperframe==5.2.0         # via h2
-idna==2.10                # via httpx, requests
-kubernetes==11.0.0        # via synse_server (setup.py)
-multidict==4.7.6          # via sanic
+idna==2.10                # via requests
+kubernetes==12.0.1        # via synse_server (setup.py)
+multidict==5.1.0          # via sanic
 oauthlib==3.1.0           # via requests-oauthlib
-prometheus-client==0.8.0  # via synse_server (setup.py)
-protobuf==3.13.0          # via synse-grpc
+prometheus-client==0.9.0  # via synse_server (setup.py)
+protobuf==3.15.6          # via synse-grpc
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 python-dateutil==2.8.1    # via kubernetes
-pyyaml==5.3.1             # via bison, kubernetes, synse_server (setup.py)
+pyyaml==5.4.1             # via bison, kubernetes, synse_server (setup.py)
 requests-oauthlib==1.3.0  # via kubernetes
-requests==2.24.0          # via kubernetes, requests-oauthlib
-rfc3986==1.4.0            # via httpx
-rsa==4.6                  # via google-auth
-sanic==20.6.3             # via synse_server (setup.py)
+requests==2.25.1          # via kubernetes, requests-oauthlib
+rsa==4.7.2                # via google-auth
+sanic-routing==0.4.2      # via sanic
+sanic==21.3.2             # via synse_server (setup.py)
 shortuuid==1.0.1          # via synse_server (setup.py)
-six==1.15.0               # via google-auth, grpcio, kubernetes, protobuf, python-dateutil, structlog, websocket-client
-sniffio==1.1.0            # via httpx
-structlog==20.1.0         # via synse_server (setup.py)
+six==1.15.0               # via google-auth, grpcio, kubernetes, protobuf, python-dateutil, websocket-client
+structlog==21.1.0         # via synse_server (setup.py)
 synse-grpc==3.1.0         # via synse_server (setup.py)
-ujson==2.0.3              # via sanic
-urllib3==1.25.10          # via httpx, kubernetes, requests
-uvloop==0.14.0            # via sanic
-websocket-client==0.57.0  # via kubernetes
+ujson==4.0.2              # via sanic
+urllib3==1.26.4           # via kubernetes, requests
+uvloop==0.15.2            # via sanic
+websocket-client==0.58.0  # via kubernetes
 websockets==8.1           # via sanic, synse_server (setup.py)
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'bison>=0.1.0',
         'grpcio',
         'kubernetes',
-        'pyyaml>=4.2b1',
+        'pyyaml>=5.4',
         'sanic>=0.8.0',
         'prometheus-client',
         'shortuuid',

--- a/synse_server/app.py
+++ b/synse_server/app.py
@@ -13,38 +13,6 @@ from synse_server.api import http, websocket
 logger = structlog.get_logger()
 
 
-def new_app() -> Sanic:
-    """Create a new instance of the Synse Server Sanic application.
-
-    Returns:
-        A Sanic application for Synse Server.
-    """
-
-    app = Sanic(
-        name='synse-server',
-        error_handler=errors.SynseErrorHandler(),
-        configure_logging=False,
-    )
-
-    # Disable the default Sanic logo.
-    app.config.LOGO = None
-
-    # Register the endpoint blueprints with the application.
-    app.blueprint(http.core)
-    app.blueprint(http.v3)
-    app.blueprint(websocket.v3)
-
-    # Add favicon. This will add a favicon, preventing errors being logged when
-    # a browser hits an endpoint and can't find the icon.
-    app.static('/favicon.ico', '/etc/synse/static/favicon.ico')
-
-    # Register middleware with the application.
-    app.register_middleware(on_request, 'request')
-    app.register_middleware(on_response, 'response')
-
-    return app
-
-
 def on_request(request: Request) -> None:
     """Middleware function that runs prior to processing a request via Sanic."""
     # Generate a unique request ID and use it as a field in any logging that
@@ -88,3 +56,42 @@ def on_response(request: Request, response: HTTPResponse) -> None:
     contextvars.unbind_contextvars(
         'request_id',
     )
+
+
+
+# def new_app(name=None) -> Sanic:
+#     """Create a new instance of the Synse Server Sanic application.
+#
+#     Args:
+#         name: Name of the application. This allows tests to create application
+#             instances with different names.
+#
+#     Returns:
+#         A Sanic application for Synse Server.
+#     """
+
+app = Sanic(
+    name='synse-server',
+    error_handler=errors.SynseErrorHandler(),
+    configure_logging=False,
+)
+
+# Disable the default Sanic logo.
+app.config.LOGO = None
+
+# Register the endpoint blueprints with the application.
+app.blueprint(http.core)
+app.blueprint(http.v3)
+app.blueprint(websocket.v3)
+
+# Add favicon. This will add a favicon, preventing errors being logged when
+# a browser hits an endpoint and can't find the icon.
+app.static('/favicon.ico', '/etc/synse/static/favicon.ico')
+
+# Register middleware with the application.
+app.register_middleware(on_request, 'request')
+app.register_middleware(on_response, 'response')
+
+    # return app
+
+

--- a/synse_server/app.py
+++ b/synse_server/app.py
@@ -58,18 +58,6 @@ def on_response(request: Request, response: HTTPResponse) -> None:
     )
 
 
-
-# def new_app(name=None) -> Sanic:
-#     """Create a new instance of the Synse Server Sanic application.
-#
-#     Args:
-#         name: Name of the application. This allows tests to create application
-#             instances with different names.
-#
-#     Returns:
-#         A Sanic application for Synse Server.
-#     """
-
 app = Sanic(
     name='synse-server',
     error_handler=errors.SynseErrorHandler(),
@@ -91,7 +79,3 @@ app.static('/favicon.ico', '/etc/synse/static/favicon.ico')
 # Register middleware with the application.
 app.register_middleware(on_request, 'request')
 app.register_middleware(on_response, 'response')
-
-    # return app
-
-

--- a/synse_server/server.py
+++ b/synse_server/server.py
@@ -79,7 +79,7 @@ class Synse:
         self._initialize()
 
         # With setup complete, we can initialize a new Sanic application.
-        self.app = app.new_app()
+        self.app = app.app
 
         # The Sanic asyncio server
         self.server = None

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -5,3 +5,5 @@ pytest
 pytest-asyncio
 pytest-cov
 pytest-mock
+requests
+sanic-testing

--- a/tests/unit/api/test_http.py
+++ b/tests/unit/api/test_http.py
@@ -22,7 +22,7 @@ class TestCoreTest:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/test', gather_request=False)
+        _, response = fn('/test', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -32,7 +32,7 @@ class TestCoreTest:
                 'timestamp': '2019-04-22T13:30:00Z',
             }
 
-            resp = synse_app.test_client.get('/test', gather_request=False)
+            _, resp = synse_app.test_client.get('/test', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -57,7 +57,7 @@ class TestCoreVersion:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/version', gather_request=False)
+        _, response = fn('/version', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -67,7 +67,7 @@ class TestCoreVersion:
                 'api_version': 'v3',
             }
 
-            resp = synse_app.test_client.get('/version', gather_request=False)
+            _, resp = synse_app.test_client.get('/version', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -93,7 +93,7 @@ class TestV3Config:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/config', gather_request=False)
+        _, response = fn('/v3/config', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -107,7 +107,7 @@ class TestV3Config:
                 }
             }
 
-            resp = synse_app.test_client.get('/v3/config', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/config', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -120,7 +120,7 @@ class TestV3Config:
         with asynctest.patch('synse_server.cmd.config') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/config', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/config', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -151,7 +151,7 @@ class TestV3Plugins:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/plugin', gather_request=False)
+        _, response = fn('/v3/plugin', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -173,7 +173,7 @@ class TestV3Plugins:
                 },
             ]
 
-            resp = synse_app.test_client.get('/v3/plugin', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/plugin', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -186,7 +186,7 @@ class TestV3Plugins:
         with asynctest.patch('synse_server.cmd.plugins') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/plugin', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/plugin', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -217,7 +217,7 @@ class TestV3Plugin:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/plugin/123', gather_request=False)
+        _, response = fn('/v3/plugin/123', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -238,7 +238,7 @@ class TestV3Plugin:
                 },
             }
 
-            resp = synse_app.test_client.get('/v3/plugin/12345', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/plugin/12345', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -252,7 +252,7 @@ class TestV3Plugin:
         with asynctest.patch('synse_server.cmd.plugin') as mock_cmd:
             mock_cmd.side_effect = errors.NotFound('plugin not found')
 
-            resp = synse_app.test_client.get('/v3/plugin/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/plugin/123', gather_request=False)
             assert resp.status == 404
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -271,7 +271,7 @@ class TestV3Plugin:
         with asynctest.patch('synse_server.cmd.plugin') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/plugin/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/plugin/123', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -303,7 +303,7 @@ class TestV3PluginHealth:
     )
     def test_health_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/plugin/health', gather_request=False)
+        _, response = fn('/v3/plugin/health', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -321,7 +321,7 @@ class TestV3PluginHealth:
                 'inactive': 1,
             }
 
-            resp = synse_app.test_client.get('/v3/plugin/health', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/plugin/health', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -334,7 +334,7 @@ class TestV3PluginHealth:
         with asynctest.patch('synse_server.cmd.plugin_health') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/plugin/health', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/plugin/health', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -365,7 +365,7 @@ class TestV3Scan:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/scan', gather_request=False)
+        _, response = fn('/v3/scan', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -391,7 +391,7 @@ class TestV3Scan:
                 },
             ]
 
-            resp = synse_app.test_client.get('/v3/scan', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/scan', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -410,7 +410,7 @@ class TestV3Scan:
         with asynctest.patch('synse_server.cmd.scan') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/scan', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/scan', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -433,7 +433,7 @@ class TestV3Scan:
     def test_invalid_multiple_ns(self, synse_app):
         with asynctest.patch('synse_server.cmd.scan') as mock_cmd:
 
-            resp = synse_app.test_client.get('/v3/scan?ns=ns-1&ns=ns-2', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/scan?ns=ns-1&ns=ns-2', gather_request=False)
             assert resp.status == 400
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -450,7 +450,7 @@ class TestV3Scan:
     def test_invalid_multiple_sort(self, synse_app):
         with asynctest.patch('synse_server.cmd.scan') as mock_cmd:
 
-            resp = synse_app.test_client.get('/v3/scan?sort=id&sort=type', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/scan?sort=id&sort=type', gather_request=False)
             assert resp.status == 400
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -488,7 +488,7 @@ class TestV3Scan:
                 },
             ]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/scan' + qparam,
                 gather_request=False,
             )
@@ -529,7 +529,7 @@ class TestV3Scan:
                 },
             ]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/scan' + qparam,
                 gather_request=False,
             )
@@ -579,7 +579,7 @@ class TestV3Scan:
                 },
             ]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/scan' + qparam,
                 gather_request=False,
             )
@@ -623,7 +623,7 @@ class TestV3Scan:
                 },
             ]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/scan' + qparam,
                 gather_request=False,
             )
@@ -658,7 +658,7 @@ class TestV3Tags:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/tags', gather_request=False)
+        _, response = fn('/v3/tags', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -669,7 +669,7 @@ class TestV3Tags:
                 'vapor/unit:test',
             ]
 
-            resp = synse_app.test_client.get('/v3/tags', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/tags', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -686,7 +686,7 @@ class TestV3Tags:
         with asynctest.patch('synse_server.cmd.tags') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/tags', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/tags', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -722,7 +722,7 @@ class TestV3Tags:
                 'vapor/unit:test',
             ]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/tags' + qparam,
                 gather_request=False,
             )
@@ -764,7 +764,7 @@ class TestV3Tags:
                 'vapor/unit:test',
             ]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/tags' + qparam,
                 gather_request=False,
             )
@@ -797,7 +797,7 @@ class TestV3Info:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/info/123', gather_request=False)
+        _, response = fn('/v3/info/123', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -811,7 +811,7 @@ class TestV3Info:
                 ],
             }
 
-            resp = synse_app.test_client.get('/v3/info/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/info/123', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -825,7 +825,7 @@ class TestV3Info:
         with asynctest.patch('synse_server.cmd.info') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/info/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/info/123', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -844,7 +844,7 @@ class TestV3Info:
         with asynctest.patch('synse_server.cmd.info') as mock_cmd:
             mock_cmd.side_effect = errors.NotFound('device not found')
 
-            resp = synse_app.test_client.get('/v3/info/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/info/123', gather_request=False)
             assert resp.status == 404
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -876,7 +876,7 @@ class TestV3Read:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/read', gather_request=False)
+        _, response = fn('/v3/read', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -888,7 +888,7 @@ class TestV3Read:
                 },
             ]
 
-            resp = synse_app.test_client.get('/v3/read', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/read', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -906,7 +906,7 @@ class TestV3Read:
         with asynctest.patch('synse_server.cmd.read') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/read', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/read', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -928,7 +928,7 @@ class TestV3Read:
     def test_invalid_multiple_ns(self, synse_app):
         with asynctest.patch('synse_server.cmd.read') as mock_cmd:
 
-            resp = synse_app.test_client.get('/v3/read?ns=ns-1&ns=ns-2', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/read?ns=ns-1&ns=ns-2', gather_request=False)
             assert resp.status == 400
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -963,7 +963,7 @@ class TestV3Read:
                 },
             ]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/read' + qparam,
                 gather_request=False,
             )
@@ -999,7 +999,7 @@ class TestV3Read:
                 },
             ]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/read' + qparam,
                 gather_request=False,
             )
@@ -1023,7 +1023,7 @@ class TestV3Read:
                 '123456': None,
             })
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/read?plugin=123456',
                 gather_request=False,
             )
@@ -1043,7 +1043,7 @@ class TestV3Read:
         with asynctest.patch('synse_server.cmd.read') as mock_cmd:
             mock_cmd.return_value = [{'value': 1, 'type': 'temperature'}]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/read?plugin=123456',
                 gather_request=False,
             )
@@ -1069,7 +1069,7 @@ class TestV3ReadCache:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/readcache', gather_request=False)
+        _, response = fn('/v3/readcache', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -1099,7 +1099,7 @@ class TestV3ReadCache:
         with asynctest.patch('synse_server.api.http.cmd.read_cache') as mock_cmd:
             mock_cmd.side_effect = mock_read_cache
 
-            resp = synse_app.test_client.get('/v3/readcache', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/readcache', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Transfer-Encoding'] == 'chunked'
             assert resp.headers['Content-Type'] == 'application/json; charset=utf-8'
@@ -1124,7 +1124,7 @@ class TestV3ReadCache:
         with asynctest.patch('synse_server.cmd.read_cache') as mock_cmd:
             mock_cmd.side_effect = mock_read_cache
 
-            resp = synse_app.test_client.get('/v3/readcache', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/readcache', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Transfer-Encoding'] == 'chunked'
             assert resp.headers['Content-Type'] == 'application/json; charset=utf-8'
@@ -1139,7 +1139,7 @@ class TestV3ReadCache:
     def test_invalid_multiple_start(self, synse_app):
         with asynctest.patch('synse_server.cmd.read_cache') as mock_cmd:
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/readcache?start=123&start=321',
                 gather_request=False,
             )
@@ -1160,7 +1160,7 @@ class TestV3ReadCache:
         with asynctest.patch('synse_server.cmd.read_cache') as mock_cmd:
             mock_cmd.side_effect = errors.InvalidUsage('invalid: end')
 
-            resp = synse_app.test_client.get('/v3/readcache?end=123&end=321', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/readcache?end=123&end=321', gather_request=False)
             assert resp.status == 400
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1200,7 +1200,7 @@ class TestV3ReadCache:
         with asynctest.patch('synse_server.cmd.read_cache') as mock_cmd:
             mock_cmd.side_effect = mock_read_cache
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/readcache' + qparam,
                 gather_request=False,
             )
@@ -1241,7 +1241,7 @@ class TestV3ReadCache:
         with asynctest.patch('synse_server.cmd.read_cache') as mock_cmd:
             mock_cmd.side_effect = mock_read_cache
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/readcache' + qparam,
                 gather_request=False,
             )
@@ -1273,7 +1273,7 @@ class TestV3ReadDevice:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/read/123', gather_request=False)
+        _, response = fn('/v3/read/123', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -1289,7 +1289,7 @@ class TestV3ReadDevice:
                 },
             ]
 
-            resp = synse_app.test_client.get('/v3/read/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/read/123', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1303,7 +1303,7 @@ class TestV3ReadDevice:
         with asynctest.patch('synse_server.cmd.read_device') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/read/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/read/123', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1322,7 +1322,7 @@ class TestV3ReadDevice:
         with asynctest.patch('synse_server.cmd.read_device') as mock_cmd:
             mock_cmd.side_effect = errors.NotFound('device not found')
 
-            resp = synse_app.test_client.get('/v3/read/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/read/123', gather_request=False)
             assert resp.status == 404
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1341,7 +1341,7 @@ class TestV3ReadDevice:
         with asynctest.patch('synse_server.cmd.read_device') as mock_cmd:
             mock_cmd.side_effect = errors.UnsupportedAction('not supported')
 
-            resp = synse_app.test_client.get('/v3/read/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/read/123', gather_request=False)
             assert resp.status == 405
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1373,7 +1373,7 @@ class TestV3AsyncWrite:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/write/123', gather_request=False)
+        _, response = fn('/v3/write/123', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -1389,7 +1389,7 @@ class TestV3AsyncWrite:
                 },
             ]
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/123',
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,
@@ -1410,7 +1410,7 @@ class TestV3AsyncWrite:
         with asynctest.patch('synse_server.cmd.write_async') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/123',
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,
@@ -1435,7 +1435,7 @@ class TestV3AsyncWrite:
     def test_invalid_json(self, synse_app):
         with asynctest.patch('synse_server.cmd.write_async') as mock_cmd:
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/123',
                 data='invalid json data',
                 gather_request=False,
@@ -1456,7 +1456,7 @@ class TestV3AsyncWrite:
     def test_invalid_json_missing_key(self, synse_app):
         with asynctest.patch('synse_server.cmd.write_async') as mock_cmd:
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/123',
                 data=ujson.dumps({'data': 'bar'}),
                 gather_request=False,
@@ -1478,7 +1478,7 @@ class TestV3AsyncWrite:
         with asynctest.patch('synse_server.cmd.write_async') as mock_cmd:
             mock_cmd.side_effect = errors.NotFound('device not found')
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/123',
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,
@@ -1504,7 +1504,7 @@ class TestV3AsyncWrite:
         with asynctest.patch('synse_server.cmd.write_async') as mock_cmd:
             mock_cmd.side_effect = errors.UnsupportedAction('not supported')
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/123',
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,
@@ -1543,7 +1543,7 @@ class TestV3SyncWrite:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/write/wait/123', gather_request=False)
+        _, response = fn('/v3/write/wait/123', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -1559,7 +1559,7 @@ class TestV3SyncWrite:
                 },
             ]
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/wait/123',
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,
@@ -1580,7 +1580,7 @@ class TestV3SyncWrite:
         with asynctest.patch('synse_server.cmd.write_sync') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/wait/123',
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,
@@ -1605,7 +1605,7 @@ class TestV3SyncWrite:
     def test_invalid_json(self, synse_app):
         with asynctest.patch('synse_server.cmd.write_sync') as mock_cmd:
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/wait/123',
                 data='invalid json data',
                 gather_request=False,
@@ -1626,7 +1626,7 @@ class TestV3SyncWrite:
     def test_invalid_json_missing_key(self, synse_app):
         with asynctest.patch('synse_server.cmd.write_sync') as mock_cmd:
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/wait/123',
                 data=ujson.dumps({'data': 'bar'}),
                 gather_request=False,
@@ -1648,7 +1648,7 @@ class TestV3SyncWrite:
         with asynctest.patch('synse_server.cmd.write_sync') as mock_cmd:
             mock_cmd.side_effect = errors.NotFound('device not found')
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/wait/123',
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,
@@ -1674,7 +1674,7 @@ class TestV3SyncWrite:
         with asynctest.patch('synse_server.cmd.write_sync') as mock_cmd:
             mock_cmd.side_effect = errors.UnsupportedAction('not supported')
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/wait/123',
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,
@@ -1713,7 +1713,7 @@ class TestV3Transactions:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/transaction', gather_request=False)
+        _, response = fn('/v3/transaction', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -1726,7 +1726,7 @@ class TestV3Transactions:
                 'txn-5',
             ]
 
-            resp = synse_app.test_client.get('/v3/transaction', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/transaction', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1739,7 +1739,7 @@ class TestV3Transactions:
         with asynctest.patch('synse_server.cmd.transactions') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/transaction', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/transaction', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1770,7 +1770,7 @@ class TestV3Transaction:
     )
     def test_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/transaction/123', gather_request=False)
+        _, response = fn('/v3/transaction/123', gather_request=False)
         assert response.status == 405
 
     def test_ok(self, synse_app):
@@ -1784,7 +1784,7 @@ class TestV3Transaction:
                 'timeout': '5s',
             }
 
-            resp = synse_app.test_client.get('/v3/transaction/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/transaction/123', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1798,7 +1798,7 @@ class TestV3Transaction:
         with asynctest.patch('synse_server.cmd.transaction') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/transaction/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/transaction/123', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1817,7 +1817,7 @@ class TestV3Transaction:
         with asynctest.patch('synse_server.cmd.transaction') as mock_cmd:
             mock_cmd.side_effect = errors.NotFound('transaction not found')
 
-            resp = synse_app.test_client.get('/v3/transaction/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/transaction/123', gather_request=False)
             assert resp.status == 404
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1857,7 +1857,7 @@ class TestV3Device:
     )
     def test_enumerate_methods_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/device', gather_request=False)
+        _, response = fn('/v3/device', gather_request=False)
         assert response.status == 405
 
     def test_enumerate_ok(self, synse_app):
@@ -1883,7 +1883,7 @@ class TestV3Device:
                 },
             ]
 
-            resp = synse_app.test_client.get('/v3/device', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/device', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1902,7 +1902,7 @@ class TestV3Device:
         with asynctest.patch('synse_server.cmd.scan') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/device', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/device', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1924,7 +1924,7 @@ class TestV3Device:
 
     def test_enumerate_invalid_multiple_ns(self, synse_app):
         with asynctest.patch('synse_server.cmd.scan') as mock_cmd:
-            resp = synse_app.test_client.get('/v3/device?ns=ns-1&ns=ns-2', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/device?ns=ns-1&ns=ns-2', gather_request=False)
             assert resp.status == 400
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1940,7 +1940,7 @@ class TestV3Device:
 
     def test_enumerate_invalid_multiple_sort(self, synse_app):
         with asynctest.patch('synse_server.cmd.scan') as mock_cmd:
-            resp = synse_app.test_client.get('/v3/device?sort=id&sort=type', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/device?sort=id&sort=type', gather_request=False)
             assert resp.status == 400
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1978,7 +1978,7 @@ class TestV3Device:
                 },
             ]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/device' + qparam,
                 gather_request=False,
             )
@@ -2019,7 +2019,7 @@ class TestV3Device:
                 },
             ]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/device' + qparam,
                 gather_request=False,
             )
@@ -2069,7 +2069,7 @@ class TestV3Device:
                 },
             ]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/device' + qparam,
                 gather_request=False,
             )
@@ -2113,7 +2113,7 @@ class TestV3Device:
                 },
             ]
 
-            resp = synse_app.test_client.get(
+            _, resp = synse_app.test_client.get(
                 '/v3/device' + qparam,
                 gather_request=False,
             )
@@ -2146,7 +2146,7 @@ class TestV3Device:
     )
     def test_not_allowed(self, synse_app, method):
         fn = getattr(synse_app.test_client, method)
-        response = fn('/v3/device/123', gather_request=False)
+        _, response = fn('/v3/device/123', gather_request=False)
         assert response.status == 405
 
     def test_read_ok(self, synse_app):
@@ -2162,7 +2162,7 @@ class TestV3Device:
                 },
             ]
 
-            resp = synse_app.test_client.get('/v3/device/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/device/123', gather_request=False)
             assert resp.status == 200
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -2176,7 +2176,7 @@ class TestV3Device:
         with asynctest.patch('synse_server.cmd.read_device') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.get('/v3/device/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/device/123', gather_request=False)
             assert resp.status == 500
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -2195,7 +2195,7 @@ class TestV3Device:
         with asynctest.patch('synse_server.cmd.read_device') as mock_cmd:
             mock_cmd.side_effect = errors.NotFound('device not found')
 
-            resp = synse_app.test_client.get('/v3/read/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/read/123', gather_request=False)
             assert resp.status == 404
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -2214,7 +2214,7 @@ class TestV3Device:
         with asynctest.patch('synse_server.cmd.read_device') as mock_cmd:
             mock_cmd.side_effect = errors.UnsupportedAction('not supported')
 
-            resp = synse_app.test_client.get('/v3/read/123', gather_request=False)
+            _, resp = synse_app.test_client.get('/v3/read/123', gather_request=False)
             assert resp.status == 405
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -2242,7 +2242,7 @@ class TestV3Device:
                 },
             ]
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/device/123',
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,
@@ -2263,7 +2263,7 @@ class TestV3Device:
         with asynctest.patch('synse_server.cmd.write_sync') as mock_cmd:
             mock_cmd.side_effect = ValueError('***********')
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/wait/123',
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,
@@ -2288,7 +2288,7 @@ class TestV3Device:
     def test_write_invalid_json(self, synse_app):
         with asynctest.patch('synse_server.cmd.write_sync') as mock_cmd:
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/wait/123',
                 data='invalid json data',
                 gather_request=False,
@@ -2309,7 +2309,7 @@ class TestV3Device:
     def test_write_invalid_json_missing_key(self, synse_app):
         with asynctest.patch('synse_server.cmd.write_sync') as mock_cmd:
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/wait/123',
                 data=ujson.dumps({'data': 'bar'}),
                 gather_request=False,
@@ -2331,7 +2331,7 @@ class TestV3Device:
         with asynctest.patch('synse_server.cmd.write_sync') as mock_cmd:
             mock_cmd.side_effect = errors.NotFound('device not found')
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/wait/123',
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,
@@ -2357,7 +2357,7 @@ class TestV3Device:
         with asynctest.patch('synse_server.cmd.write_sync') as mock_cmd:
             mock_cmd.side_effect = errors.UnsupportedAction('not supported')
 
-            resp = synse_app.test_client.post(
+            _, resp = synse_app.test_client.post(
                 '/v3/write/wait/123',
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,

--- a/tests/unit/api/test_http.py
+++ b/tests/unit/api/test_http.py
@@ -1160,7 +1160,8 @@ class TestV3ReadCache:
         with asynctest.patch('synse_server.cmd.read_cache') as mock_cmd:
             mock_cmd.side_effect = errors.InvalidUsage('invalid: end')
 
-            _, resp = synse_app.test_client.get('/v3/readcache?end=123&end=321', gather_request=False)
+            _, resp = synse_app.test_client.get(
+                '/v3/readcache?end=123&end=321', gather_request=False)
             assert resp.status == 400
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -1940,7 +1941,8 @@ class TestV3Device:
 
     def test_enumerate_invalid_multiple_sort(self, synse_app):
         with asynctest.patch('synse_server.cmd.scan') as mock_cmd:
-            _, resp = synse_app.test_client.get('/v3/device?sort=id&sort=type', gather_request=False)
+            _, resp = synse_app.test_client.get(
+                '/v3/device?sort=id&sort=type', gather_request=False)
             assert resp.status == 400
             assert resp.headers['Content-Type'] == 'application/json'
 
@@ -2247,7 +2249,7 @@ class TestV3Device:
                 data=ujson.dumps({'action': 'foo', 'data': 'bar'}),
                 gather_request=False,
             )
-            assert resp.status == 200
+            assert resp.status == 200, resp.body
             assert resp.headers['Content-Type'] == 'application/json'
 
             body = ujson.loads(resp.body)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,12 +1,11 @@
 """Fixture definitions for Synse Server unit tests."""
-
 import datetime
 import logging
 
 import asynctest
 import pytest
-from synse_grpc import api, client
 from sanic_testing import TestManager
+from synse_grpc import api, client
 
 from synse_server import app, cache, plugin, utils
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,6 +6,7 @@ import logging
 import asynctest
 import pytest
 from synse_grpc import api, client
+from sanic_testing import TestManager
 
 from synse_server import app, cache, plugin, utils
 
@@ -216,4 +217,5 @@ def state_reading():
 def synse_app():
     """Fixture to return an instance of the Synse Sanic application for testing."""
 
-    yield app.new_app()
+    TestManager(app.app)
+    yield app.app

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -30,13 +30,13 @@ def test_on_response_normal_http_response():
     contextvars.bind_contextvars(
         request_id='test-request',
     )
-    ctx = contextvars._get_context()
-    assert 'test-request' == ctx.get('request_id')
+    ctx = contextvars._CONTEXT_VARS
+    assert 'test-request' == ctx['structlog_request_id'].get()
 
     app.on_response(req, resp)
 
-    ctx = contextvars._get_context()
-    assert ctx.get('request_id') is None
+    ctx = contextvars._CONTEXT_VARS
+    assert ctx['structlog_request_id'].get() is Ellipsis
 
 
 def test_on_response_streaming_http_response():
@@ -50,10 +50,10 @@ def test_on_response_streaming_http_response():
     contextvars.bind_contextvars(
         request_id='test-request',
     )
-    ctx = contextvars._get_context()
-    assert 'test-request' == ctx.get('request_id')
+    ctx = contextvars._CONTEXT_VARS
+    assert 'test-request' == ctx['structlog_request_id'].get()
 
     app.on_response(req, resp)
 
-    ctx = contextvars._get_context()
-    assert ctx.get('request_id') is None
+    ctx = contextvars._CONTEXT_VARS
+    assert ctx['structlog_request_id'].get() is Ellipsis

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -7,7 +7,7 @@ from synse_server import app, errors
 
 
 def test_new_app():
-    synse_app = app.new_app()
+    synse_app = app.app
 
     assert synse_app.name == 'synse-server'
     assert isinstance(synse_app.error_handler, errors.SynseErrorHandler)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -41,10 +41,12 @@ class TestSynse:
     @mock.patch('sys.stdout.write')
     def test_run_ok_with_metrics(self, mock_write, mock_ruc, mock_run, mock_init):
         synse = server.Synse()
-        assert 'metrics' not in synse.app.router.routes_names.keys()
+
+        assert ('metrics',) not in synse.app.router.routes_all
 
         synse.run()
-        assert 'metrics' in synse.app.router.routes_names.keys()
+
+        assert ('metrics',) in synse.app.router.routes_all
 
         mock_write.assert_called_once()
         mock_init.assert_called_once()


### PR DESCRIPTION
This PR:
- Updates to the latest dependencies, pulling in a lot of updates with major version bumps and thus breaking changes
- Updates lots of things ranging from test expectations, app metadata layout, changed expectations about app global state, weird update to route referencing

I'm not overall pleased with the latest sanic updates because a lot has changed, and while the major version was bumped accordingly, some of these changes took a lot of effort to track down what was happening. while I'm sure there was good reason for the changes, they do step on how some of our tests were set up. I think longer term, its probably worth moving to fastapi, if only for the better openapi support, but thats neither here nor there.

The driver for this PR was to update pyyaml so we are using the version which fixes the CVE it has. 

A future PR will update how dependency management is done here so we can have more fine-grained control over updates.

fixes #418 

Note: I will **not** cut a new release of Synse Server after this because I still want to do some local testing to make sure nothing else is funky. Expect a new release for this in the coming weeks.