### PR TITLE
dev: update chartreleaser config - no longer need to specify extras

### DIFF
--- a/.chartreleaser.yml
+++ b/.chartreleaser.yml
@@ -9,17 +9,8 @@ chart:
   path: synse-server
 publish:
   pr:
-    title_template: '[{{ .Chart.Name }}] bump app version from {{ .Chart.PreviousVersion}} to {{ .Chart.NewVersion }}'
+    title_template: '[{{ .Chart.Name }}] bump app version from {{ .App.PreviousVersion}} to {{ .App.NewVersion }}'
 commit:
   author:
     name: vio-bot
     email: marco+viogh@vapor.io
-extras:
-- path: synse-server/README.md
-  updates:
-  - search: '\| `image\.tag` \| The tag of the image to use\. \| `[0-9a-zA-Z.-]*` \|'
-    replace: '| `image.tag` | The tag of the image to use. | `{{ .App.NewVersion }}` |'
-- path: synse-server/values.yaml
-  updates:
-  - search: 'tag: "[0-9a-zA-Z.-]*"'
-    replace: 'tag: "{{ .App.NewVersion }}"'


### PR DESCRIPTION
This PR:
- updates the chartreleaser config to better model the chart updates we need for the updated helmv3 synse chart