### PR TITLE
bugfix: fix json encoder config to allow bytes

### DIFF
--- a/synse_server/api/http.py
+++ b/synse_server/api/http.py
@@ -410,7 +410,10 @@ async def read_cache(request: Request) -> StreamingHTTPResponse:
         # just log it and move on.
         try:
             async for reading in cmd.read_cache(start, end):
-                await response.write(ujson.dumps(reading) + '\n')
+                try:
+                    await response.write(ujson.dumps(reading, reject_bytes=False) + '\n')
+                except Exception:
+                    logger.exception('error streaming cached reading response', reading=reading)
         except Exception:
             logger.exception('failure when streaming cached readings')
 

--- a/synse_server/utils.py
+++ b/synse_server/utils.py
@@ -66,7 +66,7 @@ def _dumps(*arg, **kwargs) -> str:
     Returns:
         The given dictionary data dumped to a JSON string.
     """
-    out = ujson.dumps(*arg, **kwargs)
+    out = ujson.dumps(*arg, reject_bytes=False, **kwargs)
     if not out.endswith('\n'):
         out += '\n'
     return out

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -45,6 +45,11 @@ def test_rfc3339now():
         ([1, 2, 3], '[1,2,3]\n'),
         ([1, 2, [2, 3, 4]], '[1,2,[2,3,4]]\n'),
         ([{'one': 1}, {'two': 2}], '[{"one":1},{"two":2}]\n'),
+
+        # -- Regression tests for https://vaporio.atlassian.net/browse/VIO-1278
+        ({b'foo': 'bar'}, '{"foo":"bar"}\n'),
+        ({'foo': b'bar'}, '{"foo":"bar"}\n'),
+        ({b'foo': b'bar'}, '{"foo":"bar"}\n'),
     ],
 )
 def test_dumps(data, expected):


### PR DESCRIPTION
This PR:
-  fixes a bug where responses were failing when plugins reported  reading values as bytes because  the json encoder evidently rejects bytes by default.

Once this lands, I'll bump the version and cut a new release.

[VIO-1278]

[VIO-1278]: https://vaporio.atlassian.net/browse/VIO-1278