### PR TITLE
bugfix: convert NaN to None when parsing readings [VIO-1369]

### DIFF
--- a/synse_server/cmd/read.py
+++ b/synse_server/cmd/read.py
@@ -1,5 +1,6 @@
 
 import asyncio
+import math
 import queue
 import threading
 from typing import Any, AsyncIterable, Dict, List, Optional, Union
@@ -31,6 +32,17 @@ def reading_to_dict(reading: api.V3Reading) -> Dict[str, Any]:
     field = reading.WhichOneof('value')
     if field is not None:
         value = getattr(reading, field)
+
+        # Ensure the value is not NaN, as NaN is not a part of the
+        # JSON spec and could cause clients to error.
+        try:
+            float(value)
+        except ValueError:
+            # Not a real number, nothing to do.
+            pass
+        else:
+            if math.isnan(value):
+                value = None
 
     if not reading.unit or (reading.unit.symbol == '' and reading.unit.name == ''):
         unit = None

--- a/tests/unit/cmd/test_read.py
+++ b/tests/unit/cmd/test_read.py
@@ -2,7 +2,7 @@
 
 import asynctest
 import pytest
-from synse_grpc import client
+from synse_grpc import api, client
 
 from synse_server import cmd, errors, plugin
 from synse_server.cmd.read import reading_to_dict
@@ -672,6 +672,35 @@ def test_reading_to_dict_3(state_reading):
         'device_type': 'led',
         'device_info': 'Example LED Device',
         'value': 'on',
+        'unit': None,
+        'context': {},
+    }
+
+
+def test_reading_to_dict_4_nan(state_reading):
+    """Handle NaN when converting the gRPC message to JSON, as NaN is not
+    part of the JSON spec. NaN should be converted to None.
+
+    Regression for: https://vaporio.atlassian.net/browse/VIO-1369
+    """
+
+    msg = api.V3Reading(
+        id='ddd',
+        timestamp='2019-04-22T13:30:00Z',
+        type='temperature',
+        deviceType='temperature',
+        deviceInfo='Example Temperature Device',
+        float64_value=float('nan'),
+    )
+
+    actual = reading_to_dict(msg)
+    assert actual == {
+        'device': 'ddd',
+        'timestamp': '2019-04-22T13:30:00Z',
+        'type': 'temperature',
+        'device_type': 'temperature',
+        'device_info': 'Example Temperature Device',
+        'value': None,
         'unit': None,
         'context': {},
     }


### PR DESCRIPTION
This PR:

- converts any NaN received by plugin read to None, as NaN is not part of the JSON spec and could break clients (where `None` gets converted to `null`).

fixes [VIO-1369]

[VIO-1369]: https://vaporio.atlassian.net/browse/VIO-1369