### PR TITLE
bugfix: support bytes from internal readings

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -218,3 +218,10 @@ def synse_app():
 
     TestManager(app.app)
     yield app.app
+
+
+@pytest.fixture()
+def const_uuid():
+    """Return a constant UUID."""
+
+    return "cadc0872-9e73-4122-bfa2-377d176374e0"


### PR DESCRIPTION
This PR:

- fixes a bug uncovered while debugging an issue with a plugin crashing the websocket connection. the crash ended up being the result of a plugin returning a  reading whose value was encoded as bytes. bytes are not JSON serializable, so synse-server was failing the read and terminating the websocket connection. this change checks for bytes and decodes to a string, then tries to load the string as JSON, keeping the result if it renders to a list or dict.
- adds unit tests

[VIO-1238]

[VIO-1238]: https://vaporio.atlassian.net/browse/VIO-1238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ