### PR TITLE
feat: add prometheus metric for total registered devices

### DIFF
--- a/synse_server/metrics.py
+++ b/synse_server/metrics.py
@@ -120,6 +120,14 @@ class Monitor:
         labelnames=('plugin',),
     )
 
+    #
+    # General / other metrics
+    #
+    registered_devices = Gauge(
+        name='synse_registered_devices',
+        documentation='The number of devices currently registered with Synse Server',
+    )
+
     def __init__(self, app: sanic.Sanic) -> None:
         self.app = app
 


### PR DESCRIPTION
This PR:
- adds a prometheus metric tracking the number of devices registered with synse server

had this sitting around for a while, so wanted to get this pushed up before I depart

fixes #411