### PR TITLE
Update .jenkins

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 // Include this shared CI repository to load script helpers and libraries.
-library identifier: 'vapor@1.20.1', retriever: modernSCM([
+library identifier: 'vapor@1.21.19', retriever: modernSCM([
   $class: 'GitSCMSource',
   remote: 'https://github.com/vapor-ware/ci-shared.git',
   credentialsId: 'vio-bot-gh',
@@ -12,6 +12,7 @@ pythonPipeline([
   'pythonVersion': '3.9',
   'mainBranch': 'develop',
   'skipIntegrationTest': true,
+  'skipClair': true,
   'releaseToPypi': false,
   'publishToGitHub': true,
 ])


### PR DESCRIPTION
bump to latest ci-shared to enable tracking of development deployments in jira