### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,14 +39,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && chown -R synse:synse /synse \
  && chown -R synse:synse /etc/synse
 
-COPY --from=builder /build/dist/synse-server-*.tar.gz /synse/synse-server.tar.gz
+COPY --from=builder /build/dist/synse_server-*.tar.gz /synse/synse_server.tar.gz
 COPY --from=builder /build/packages /pip-packages
 COPY ./assets/favicon.ico /etc/synse/static/favicon.ico
 
 WORKDIR synse
 
 RUN pip install --no-index --find-links=/pip-packages /pip-packages/* \
- && pip install synse-server.tar.gz \
+ && pip install synse_server.tar.gz \
  && rm -rf /root/.cache
 
 USER synse


### PR DESCRIPTION
Build is currently failing due to package naming likely from a package update.

```
[2/2] STEP 5/12: COPY --from=builder /build/dist/synse-server-*.tar.gz /synse/synse-server.tar.gz

Error: building at STEP "COPY --from=builder /build/dist/synse-server-*.tar.gz /synse/synse-server.tar.gz": checking on sources under "/var/lib/containers/storage/overlay/e7a985490e2d0325e42a11207d2dd8c5f6390e92a907dca72295c92308680a98/merged": Rel: can't make  relative to /var/lib/containers/storage/overlay/e7a985490e2d0325e42a11207d2dd8c5f6390e92a907dca72295c92308680a98/merged; copier: stat: ["/build/dist/synse-server-*.tar.gz"]: no such file or directory

script returned exit code 125
```